### PR TITLE
fix: 104X或之前的ISO镜像更新应用版本为5.9.6,升级前“禁用”和“收藏”的字体恢复为“启用”和“取消收藏”状态

### DIFF
--- a/deepin-font-manager/interfaces/dcomworker.cpp
+++ b/deepin-font-manager/interfaces/dcomworker.cpp
@@ -67,13 +67,21 @@ void GetFontListWorker::run()
     if (m_type == Startup) {
         thread->m_allFontPathList.clear();
         thread->m_allFontPathList = inst->getAllFontPath(true);
-
 //        removeUserAddFonts();
 
-        DFMDBManager::instance()->getAllRecords();
-        QList<DFontPreviewItemData> list = DFMDBManager::instance()->getFontInfo(50, &thread->m_delFontInfoList);
-        thread->m_startModelList = list;
-        thread->m_fontModelList.append(list);
+        if(DFMDBManager::instance()->isDBDeleted()){
+            thread->updateDb();//想把它放在第1个，getStartFontList之前
+            DFMDBManager::instance()->getAllRecords();
+            QList<DFontPreviewItemData> list = DFMDBManager::instance()->getFontInfo(50, &thread->m_delFontInfoList);//DFMDBManager::recordList
+            thread->m_fontModelList.clear();
+            thread->m_fontModelList.append(list);
+        }
+        else {
+            DFMDBManager::instance()->getAllRecords();
+            QList<DFontPreviewItemData> list = DFMDBManager::instance()->getFontInfo(50, &thread->m_delFontInfoList);
+            thread->m_startModelList = list;
+            thread->m_fontModelList.append(list);
+        }
     }
 
     if (m_type == ALL || m_type == AllInSquence) {

--- a/deepin-font-manager/interfaces/dfontpreviewlistdatathread.h
+++ b/deepin-font-manager/interfaces/dfontpreviewlistdatathread.h
@@ -95,9 +95,9 @@ public:
 
     //
     void onRefreshUserAddFont(QList<DFontInfo> &fontInfoList);
-
+    void updateDb();//当数据库表结构更新时（数据被清空），从系统读取字体配置，并将旧数据库数据更新到数据库
 private:
-    void withoutDbRefreshDb(QStringList &m_allFontPathList);
+    void withoutDbRefreshDb();
     // 添加符合条件的itemData
     void appendItemData(const DFontPreviewItemData &itemData, const bool &isStartup);
 

--- a/libdeepin-font-manager/dfmdbmanager.cpp
+++ b/libdeepin-font-manager/dfmdbmanager.cpp
@@ -568,14 +568,28 @@ void DFMDBManager::commitUpdateFontInfo()
 
     beginTransaction();
     m_sqlUtil->updateFontInfo(m_updateFontList, m_strKey);
+    //m_sqlUtil->updateOld2Record();//数据库表被重建时，先saveRecord，再updateOld2Record。
     endTransaction();
     m_updateFontList.clear();
+}
+/*************************************************************************
+ <Function>      syncOldRecords
+ <Description>   开启事务,批量更新数据，将更新语言时被删除的数据同步到新数据库中
+ <Author>        null
+ <Input>
+    <param1>     null            Description:null
+ <Return>        null            Description:null
+ <Note>          null
+*************************************************************************/
+void DFMDBManager::syncOldRecords()
+{
+    beginTransaction();
+    m_sqlUtil->updateOld2Record();//数据库表被重建时，先saveRecord，再updateOld2Record。
+    endTransaction();
 }
 
 void DFMDBManager::getAllRecords()
 {
-    QList<DFontPreviewItemData> fontItemDataList;
-
     QList<QString> keyList;
     appendAllKeys(keyList);
 

--- a/libdeepin-font-manager/dfmdbmanager.h
+++ b/libdeepin-font-manager/dfmdbmanager.h
@@ -61,6 +61,7 @@ public:
     void updateFontInfo(const QList<DFontPreviewItemData> &fontList, const QString &strKey);
     void commitUpdateFontInfo();
     void getAllRecords();
+    void syncOldRecords();
     //去除非法记录
     void checkIfEmpty();
     //开启事务
@@ -79,6 +80,8 @@ public:
         return filePath.contains("/usr/share/fonts/");
     }
 
+    //获取数据库是否被清空重建
+    bool isDBDeleted(){return m_sqlUtil->isDBDeleted();}
 private:
     DFontPreviewItemData parseRecordToItemData(const QMap<QString, QString> &record);
     QMap<QString, QString> mapItemData(DFontPreviewItemData itemData);

--- a/libdeepin-font-manager/dsqliteutil.h
+++ b/libdeepin-font-manager/dsqliteutil.h
@@ -50,6 +50,12 @@ public:
     //创建数据库表
     bool createTable();
 
+    //保存旧数据
+    int saveRecord();
+
+    //更新旧数据
+    bool updateOld2Record();
+
     //增加数据
     bool addRecord(QMap<QString, QString> data, const QString &table_name = "t_fontmanager");
 
@@ -107,6 +113,11 @@ public:
             return;
         m_query->finish();
     }
+    bool isDBDeleted(){return m_bDbDeleted;}
+    void setDBDeleted(bool isDBDeleted)
+    {
+        m_bDbDeleted = isDBDeleted;
+    }
 
     QSqlDatabase m_db;
 
@@ -116,6 +127,8 @@ protected:
 
 private:
     QString m_strDatabase;
+    QList<QMap<QString, QString> > m_lstFontRecord;
+    bool m_bDbDeleted = false;
 
     QSqlQuery *m_query;
     mutable QMutex mutex;


### PR DESCRIPTION
 切换语言时，保存“禁用”和“收藏”的数据，在后续从本地同步数据到数据库后，恢复数据。修改流程中相关步骤。

Log: 104X或之前的ISO镜像更新应用版本为5.9.6,升级前“禁用”和“收藏”的字体恢复为“启用”和“取消收藏”状态

Bug: https://pms.uniontech.com/bug-view-114553.html

Change-Id: Ic861df44029591d341b3c49b09ad98a5df43fe87