### PR TITLE
fix: 批量安装大量字体，安装完成字体加载过程中，删除~/.local/share/fonts文件夹，会出现用户字体界面显示异常/应用闪退

### DIFF
--- a/deepin-font-manager/interfaces/dfontpreviewlistdatathread.h
+++ b/deepin-font-manager/interfaces/dfontpreviewlistdatathread.h
@@ -78,8 +78,9 @@ public:
     DFontPreviewListView *getView() const;
 
     //通过DFontData信息获取DFontPreviewItemData
-    inline static DFontPreviewItemData getFontData(const FontData &fontData)
+    inline DFontPreviewItemData getFontData(const FontData &fontData)
     {
+        QMutexLocker locker(m_mutex);
         DFontPreviewItemData itemdata;
         itemdata.fontData = fontData;
 //        qDebug() << __FUNCTION__ << fontData.strFontName;

--- a/tests/src/deepin-font-manager-test/interfaces/ut_dfontpreviewlistdatathread.cpp
+++ b/tests/src/deepin-font-manager-test/interfaces/ut_dfontpreviewlistdatathread.cpp
@@ -242,11 +242,11 @@ TEST_F(TestDFontPreviewListDataThread, checkGetFontData)
 
     DFontPreviewItemData da;
 
-    da = DFontPreviewListDataThread::getFontData(data);
+    da = dfdatathead->getFontData(data);
     EXPECT_TRUE(da.appFontId == 2);
 
     data.strFontName = "bbb";
-    da = DFontPreviewListDataThread::getFontData(data);
+    da = dfdatathead->getFontData(data);
     EXPECT_TRUE(da.appFontId == -1);
 
 }


### PR DESCRIPTION
 安装字体加载过程中的处理函数getFontData，将其由静态函数改为普通函数，并加锁。

Log:批量安装大量字体，安装完成字体加载过程中，删除~/.local/share/fonts文件夹，会出现用户字体界面显示异常/应用闪退

Bug: https://pms.uniontech.com/bug-view-64731.html
Change-Id: Icbd73044b8bc673529c247600ee1993452c385fc