### PR TITLE
fix: 批量安装大量字体，安装完成字体加载过程中，删除~/.local/share/fonts文件夹，会出现用户字体界面显示异常/应用闪退

### DIFF
--- a/deepin-font-manager/interfaces/dfontpreviewlistview.cpp
+++ b/deepin-font-manager/interfaces/dfontpreviewlistview.cpp
@@ -887,7 +887,9 @@ void DFontPreviewListView::selectFonts(const QStringList &fileList)
     for (int i = 0; i < filterModel->rowCount(); ++i) {
         QModelIndex index = filterModel->index(i, 0);
         FontData fdata = qvariant_cast<FontData>(m_fontPreviewProxyModel->data(index));
+        QMutexLocker locker(&m_mutex);
         DFontPreviewItemData itemData = m_dataThread->getFontData(fdata);
+        locker.unlock();
         if (itemData.fontInfo.filePath.isEmpty()) {
             qDebug() << __FUNCTION__ << fdata.strFontName;
             continue;
@@ -2094,7 +2096,7 @@ void DFontPreviewListView::updateChangedDir()
         QString filePath = itemData.fontInfo.filePath;
         QFileInfo filePathInfo(filePath);
         //如果字体文件已经不存在，则从t_manager表中删除
-        if (!filePathInfo.exists()) {
+        if (!filePath.isEmpty() && !filePathInfo.exists()) {
             //删除字体之前启用字体，防止下次重新安装后就被禁用
             enableFont((itemData).fontInfo.filePath);
             DFMDBManager::instance()->deleteFontInfo(itemData);


### PR DESCRIPTION
 安装字体加载过程中的处理函数getFontData，将其由静态函数改为普通函数，并加锁。

Log:批量安装大量字体，安装完成字体加载过程中，删除~/.local/share/fonts文件夹，会出现用户字体界面显示异常/应用闪退

Bug: https://pms.uniontech.com/bug-view-64731.html
Change-Id: I263acd4c57a7bf2b4d39917d9694c4a6b5ff1771