### PR TITLE
fix: Copy字体文件至字体目录，字体列表不会实时刷新，安装同样字体不会检测字体目录已存在相同字体

### DIFF
--- a/deepin-font-manager/views/dfinstallnormalwindow.cpp
+++ b/deepin-font-manager/views/dfinstallnormalwindow.cpp
@@ -24,6 +24,7 @@
 #include "fontmanagercore.h"
 #include "dfontpreviewlistdatathread.h"
 #include "dfinstallerrordialog.h"
+#include "dcomworker.h"
 
 #include <DApplication>
 #include <DFontSizeManager>
@@ -270,6 +271,9 @@ void DFInstallNormalWindow::verifyFontFiles()
 
     for (auto &it : m_installFiles) {
         fontInfo = m_fontInfoManager->getFontInfo(it);
+        if(m_fontInfoManager->isFontInInstalledDirs(fontInfo.filePath)){
+            needRefresh = true;
+        }
         if (Q_UNLIKELY(fontInfo.isError)) {
             m_damagedFiles.append(it);
 
@@ -662,6 +666,10 @@ void DFInstallNormalWindow::onCancelInstall()
     qDebug() << __FUNCTION__ << " called";
 #endif
     m_errCancelInstall = true;
+
+    if(needRefresh){
+        emit m_signalManager->refreshUserFont();
+    }
 }
 
 /*************************************************************************
@@ -683,6 +691,9 @@ void DFInstallNormalWindow::onContinueInstall(const QStringList &continueInstall
     //继续安装不需恢复添加按钮tab聚焦状态
     m_skipStateRecovery = true;
     batchReInstall(continueInstallFontFileList);
+    if(needRefresh){
+        emit m_signalManager->refreshUserFont();
+    }
 }
 
 /*************************************************************************

--- a/deepin-font-manager/views/dfinstallnormalwindow.h
+++ b/deepin-font-manager/views/dfinstallnormalwindow.h
@@ -185,6 +185,7 @@ private:
     friend class Worker;  //声明 Worker 为友元类
     Worker *m_pworker = nullptr;
     QThread *m_pthread = nullptr;
+    bool needRefresh = false;
 };
 
 #endif  // DFINSTALLNORMALWINDOW_H

--- a/deepin-font-manager/views/dfontmgrmainwindow.cpp
+++ b/deepin-font-manager/views/dfontmgrmainwindow.cpp
@@ -257,6 +257,8 @@ void DFontMgrMainWindow::initConnections()
 
     //安装结束后刷新字体列表
     connect(m_signalManager, &SignalManager::finishFontInstall, this, &DFontMgrMainWindow::onFontInstallFinished);
+    //安装结束后刷新字体列表
+    connect(m_signalManager, &SignalManager::refreshUserFont, this, &DFontMgrMainWindow::onRefreshUserFont);
     //字体验证框弹出
     connect(m_signalManager, &SignalManager::popInstallErrorDialog, this, [ = ] {
         m_isPopInstallErrorDialog = true;
@@ -1457,6 +1459,11 @@ void DFontMgrMainWindow::onFontInstallFinished(const QStringList &fileList)
     qDebug() << __FUNCTION__ << fileList.size();
     m_isInstallOver = true;
     m_installOutFileList = fileList;
+}
+
+void DFontMgrMainWindow::onRefreshUserFont()
+{
+    afterAllStartup();
 }
 
 /*************************************************************************

--- a/deepin-font-manager/views/dfontmgrmainwindow.h
+++ b/deepin-font-manager/views/dfontmgrmainwindow.h
@@ -295,6 +295,8 @@ public slots:
     void onLeftSiderBarItemClicked(int index = 0, bool needClearSelect = true);
     //安装后添加至listview
     void onFontInstallFinished(const QStringList &fileList);
+    //刷新用户字体列表
+    void onRefreshUserFont();
     //字体删除fc-cache操作后恢复标志位
     void onUninstallFcCacheFinish();
     //切换字体菜单后判断FontListView的结果并显示对应状态

--- a/libdeepin-font-manager/dcopyfilesmanager.cpp
+++ b/libdeepin-font-manager/dcopyfilesmanager.cpp
@@ -216,6 +216,10 @@ QString DCopyFilesManager::getTargetPath(const QString &inPath, QString &srcPath
         targetPath = src;
         return familyName;
     }
+    if(DFontInfoManager::instance()->isFontInInstalledDirs(fontInfo.filePath)){
+        targetPath = QDir::homePath() + "/.local/share/fonts" + fontInfo.filePath.mid(fontInfo.filePath.lastIndexOf("/"));
+        return familyName;
+    }
 
     const QFileInfo info(srcPath);
     QString dirName = familyName;

--- a/libdeepin-font-manager/dfontinfomanager.cpp
+++ b/libdeepin-font-manager/dfontinfomanager.cpp
@@ -639,6 +639,9 @@ DFontInfo DFontInfoManager:: getFontInfo(const QString &filePath, bool withPrevi
     } /*else {
         fontInfo.isInstalled = isFontInstalled(fontInfo);
     }*/
+    if(!fontInfo.isInstalled){
+        fontInfo.isInstalled = isFontInInstalledDirs(fontInfo.filePath);
+    }
     return fontInfo;
 }
 
@@ -936,6 +939,30 @@ bool DFontInfoManager::isFontInstalled(DFontInfo &data)
         }
     }
 
+    return false;
+}
+
+/*************************************************************************
+ <Function>      isFontInInstalledDirs
+ <Description>   检查需要安装的字体文件是否在.local/share/fonts目录下，或者是否有同名文件
+ <Author>
+ <Input>
+    <param1>     filePath        Description:待安装字体文件
+ <Return>        bool            Description:return true 是；return false 否
+ <Note>          null
+*************************************************************************/
+bool DFontInfoManager::isFontInInstalledDirs(const QString &filePath)
+{
+    if (filePath.contains(QDir::homePath() + "/.local/share/fonts/")) {
+        return true;
+    }
+    if (filePath.lastIndexOf("/") < 0){
+        return false;
+    }
+    QFile file(QDir::homePath() + "/.local/share/fonts" + filePath.mid(filePath.lastIndexOf("/")));
+    if (file.exists()) {
+        return true;
+    }
     return false;
 }
 

--- a/libdeepin-font-manager/dfontinfomanager.h
+++ b/libdeepin-font-manager/dfontinfomanager.h
@@ -166,6 +166,7 @@ public:
     QStringList getFontFamilyStyle(const QString &filePah);
     QStringList getFonts(FontTYpe type) const;
     bool isFontInstalled(DFontInfo &data);
+    bool isFontInInstalledDirs(const QString &filePath);
     void getDefaultPreview(DFontInfo &data);
     void updateSP3FamilyName(const QList<DFontInfo> &fontList, bool inFontList = false);
     void checkStyleName(DFontInfo &f);

--- a/libdeepin-font-manager/signalmanager.h
+++ b/libdeepin-font-manager/signalmanager.h
@@ -40,6 +40,10 @@ public:
 signals:
     //触发完成安装信号
     void finishFontInstall(const QStringList &fileList);
+
+    //触发刷新用户字体列表信号
+    void refreshUserFont();
+
     //触发大小改变信号
     void sizeChange(int height);
     //触发弹出字体验证框请求


### PR DESCRIPTION
 安装时检查字体在字体目录是否存在，如果存在并且用户点击继续安装时，不重新复制并刷新。如果取消，则直接刷新。

Log: Copy字体文件至字体目录，字体列表不会实时刷新，安装同样字体不会检测字体目录已存在相同字体

Bug: https://pms.uniontech.com/bug-view-63645.html
Change-Id: I7968d0b682bfa67cf38ae513ae07c46208cbfcbb