### PR TITLE
fix: 字体管理器选择文件管理器中查看，空格打开字体文件后关闭字体，文管闪退

### DIFF
--- a/deepin-font-preview-plugin/fontpreview.cpp
+++ b/deepin-font-preview-plugin/fontpreview.cpp
@@ -32,8 +32,10 @@ FontPreview::FontPreview(QObject *parent):
 
 FontPreview::~FontPreview()
 {
-    if (m_previewWidget)
-        m_previewWidget->deleteLater();
+//    https://pms.uniontech.com/bug-view-142781.html
+//    插件中不需要释放。释放会导致文管异常退出。
+//    if (m_previewWidget)
+//        m_previewWidget->deleteLater();
 }
 
 /*************************************************************************


### PR DESCRIPTION
 插件中不释放资源。

Log: 字体管理器选择文件管理器中查看，空格打开字体文件后关闭字体，文管闪退

Bug: https://pms.uniontech.com/bug-view-142781.html
Change-Id: I0aa2a143ecb9a0253e74d0cb0cf342f3e32b929a