### PR TITLE
fix: use as-needed instead of as-need

### DIFF
--- a/deepin-font-manager/CMakeLists.txt
+++ b/deepin-font-manager/CMakeLists.txt
@@ -38,7 +38,7 @@ FILE(GLOB LIB_SRC_FILES ${LIB_DIR}/*.cpp ${LIB_DIR}/*.h)
 #INSTALL(FILES ${LIB_DIR}/schemas/com.deepin.font-manager.gschema.xml
 #        DESTINATION /usr/share/glib-2.0/schemas)
 #用deepin-turbo对Dapplication进行加速
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--as-need -fPIE")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--as-needed -fPIE")
 SET(CMAKE_EXE_LINKER_FLAGS "-pie")
 
 #可执行文件


### PR DESCRIPTION
Log: Use as-needed to enhance compatibility with linker

Signed-off-by: Han Gao <rabenda.cn@gmail.com>