### PR TITLE
fix: batch install error from dde-file-manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 *.pro.user
 *.user
 obj-x86_64-linux-gnu
+.vscode/

--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,0 +1,37 @@
+test_build:
+  steps:
+    - link_package:
+        source_project: deepin:Develop:dde
+        source_package: %{SCM_REPOSITORY_NAME}
+        target_project: deepin:CI
+
+    - configure_repositories:
+        project: deepin:CI
+        repositories:
+          - name: deepin_develop
+            paths:
+              - target_project: deepin:CI
+                target_repository: deepin_develop
+            architectures:
+              - x86_64
+              - aarch64
+
+  filters:
+    event: pull_request
+
+tag_build:
+  steps:
+    - branch_package:
+        source_project: deepin:Develop:dde
+        source_package: %{SCM_REPOSITORY_NAME}
+        target_project: deepin:Unstable:dde
+  filters:
+    event: tag_push
+
+commit_build:
+  steps:
+    - trigger_services:
+        project: deepin:Develop:dde
+        package: %{SCM_REPOSITORY_NAME}
+  filters:
+    event: push

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,7 +4,7 @@ Upstream-Contact: UnionTech Software Technology Co., Ltd. <>
 Source: https://github.com/linuxdeepin/deepin-font-manager
 
 # ci
-Files: .github/*
+Files: .github/* .obs/*
 Copyright: None
 License: CC0-1.0
 

--- a/.tx/deepin.conf
+++ b/.tx/deepin.conf
@@ -1,0 +1,2 @@
+[transifex]
+branch = m20

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-font-manager (6.0.1) unstable; urgency=medium
+
+  * fix: batch install error from dde-file-manager
+  * chore(CI): add obs workflow
+
+ -- Deepin Packages Builder <packages@deepin.org>  Mon, 08 May 2023 13:05:27 +0800
+
 deepin-font-manager (5.9.13) unstable; urgency=medium
 
   * New version 5.9.13.

--- a/deepin-font-manager/views/dfontmgrmainwindow.cpp
+++ b/deepin-font-manager/views/dfontmgrmainwindow.cpp
@@ -1160,6 +1160,14 @@ void DFontMgrMainWindow::installFontFromSys(const QStringList &files)
             return;
         } else if (m_isPopInstallErrorDialog) {
             emit m_signalManager->installDuringPopErrorDialog(reduceSameFiles);
+        } else if (m_fIsInstalling || m_fontLoadingSpinner->isVisible()) {
+            qDebug() << "Font is installing , save installation task and reinstall later";
+            for(QString it: reduceSameFiles) {
+                if (!m_waitForInstall.contains(it)) {
+                    m_waitForInstall.append(it);
+                }
+            }
+            return;
         } else {
             installFont(reduceSameFiles, false);
         }
@@ -1739,6 +1747,7 @@ void DFontMgrMainWindow::onInstallWindowDestroyed(QObject *)
     //文件复制结束后,将之前移除的文件监视器添加回来
     emit  DFontPreviewListDataThread::instance()->requestAutoDirWatchers();
     m_fIsInstalling = false;
+    waitForInsert();
     qDebug() << __FUNCTION__ << "end";
 }
 
@@ -2363,6 +2372,7 @@ void DFontMgrMainWindow::hideSpinner()
     //更新选中位置和设置滚动
     m_fontPreviewListView->scrollWithTheSelected();
     m_fontPreviewListView->refreshFocuses();
+    waitForInsert();
 }
 
 void DFontMgrMainWindow::afterAllStartup()

--- a/deepin-font-manager/views/dfontmgrmainwindow.cpp
+++ b/deepin-font-manager/views/dfontmgrmainwindow.cpp
@@ -1162,7 +1162,7 @@ void DFontMgrMainWindow::installFontFromSys(const QStringList &files)
             emit m_signalManager->installDuringPopErrorDialog(reduceSameFiles);
         } else if (m_fIsInstalling || m_fontLoadingSpinner->isVisible()) {
             qDebug() << "Font is installing , save installation task and reinstall later";
-            for(QString it: reduceSameFiles) {
+            for (QString &it: reduceSameFiles) {
                 if (!m_waitForInstall.contains(it)) {
                     m_waitForInstall.append(it);
                 }


### PR DESCRIPTION
font files select and open from dde-file-manager will trigger multiple batch installation processes,
but currently the batch installation process does not support concurrency, so it is first placed in the 
candidate installation queue(m_waitForInstall) for processing.