### PR TITLE
chore: Bump version to 6.5.14

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.13.1
+  version: 6.5.14.1
   kind: app
   description: |
     font manager for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.14) unstable; urgency=medium
+
+  * chore: update translations.
+
+ -- renbin <renbin@uniontech.com>  Thu, 17 Apr 2025 10:10:05 +0800
+
 deepin-font-manager (6.5.13) unstable; urgency=medium
 
   * chore: New version 6.5.13.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.13.1
+  version: 6.5.14.1
   kind: app
   description: |
     font manager for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.13.1
+  version: 6.5.14.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
Bump version to 6.5.14

Log: Bump version to 6.5.14

## Summary by Sourcery

Chores:
- Update version number in linglong.yaml configuration files for arm64, loong64, and other platforms