### PR TITLE
chore: Update version to 6.5.15

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.14.1
+  version: 6.5.15.1
   kind: app
   description: |
     font manager for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.15) unstable; urgency=medium
+
+  * Update version to 6.5.15.
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 14 May 2025 11:22:05 +0800
+
 deepin-font-manager (6.5.14) unstable; urgency=medium
 
   * chore: update translations.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.14.1
+  version: 6.5.15.1
   kind: app
   description: |
     font manager for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.14.1
+  version: 6.5.15.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
- Bump version to 6.5.15.

log:  Bump version to 6.5.15.

## Summary by Sourcery

Chores:
- Update version from 6.5.14.1 to 6.5.15.1 in arm64, loong64, and root linglong.yaml files