### PR TITLE
feat: update changelog and version

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.16.1
+  version: 6.5.17.1
   kind: app
   description: |
     font manager for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.17) unstable; urgency=medium
+
+  * chore: New version 6.5.17.
+
+ -- xiepengfei <xiepengfei@uniontech.com>  Mon, 23 Jun 2025 12:03:28 +0800
+
 deepin-font-manager (6.5.16) unstable; urgency=medium
 
   * chore: Add position-independent code flags for CMake

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.16.1
+  version: 6.5.17.1
   kind: app
   description: |
     font manager for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.16.1
+  version: 6.5.17.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
Update changelog and version

## Summary by Sourcery

Bump deepin-font-manager to version 6.5.17.1 across packaging manifests and update the Debian changelog

Chores:
- Update version to 6.5.17.1 in ARM64, Loong64, and default linglong.yaml manifests
- Refresh Debian changelog for the new release