### PR TITLE
fix: Fix translation errors

### DIFF
--- a/translations/deepin-font-manager_he.ts
+++ b/translations/deepin-font-manager_he.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="../deepin-font-manager/views/dsplitlistwidget.cpp" line="362"/>
         <source>All Fonts</source>
-        <translation>כל המילים ה 自动生成失败，请确保提供的YAML格式正确且包含必要的字段。 </translation>
+        <translation>כל המילים ה</translation>
     </message>
     <message>
         <location filename="../deepin-font-manager/views/dsplitlistwidget.cpp" line="363"/>
@@ -332,12 +332,12 @@
     <message>
         <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="80"/>
         <source>Trademark</source>
-        <translation><path trademark></translation>
+        <translation>סימן מסחרי</translation>
     </message>
     <message>
         <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="123"/>
         <source>Copyright</source>
-        <translation><path copyright></translation>
+        <translation>זכויות יוצרים</translation>
     </message>
     <message>
         <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="124"/>


### PR DESCRIPTION
Fix translation errors

Log: Fix translation errors

## Summary by Sourcery

Correct Hebrew translations in deepin-font-manager to replace placeholders and garbled text with proper translations.

Bug Fixes:
- Fix Hebrew translation for “All Fonts” by removing auto-generated error text.
- Replace placeholder path tags with proper Hebrew for “Trademark.”
- Replace placeholder path tags with proper Hebrew for “Copyright.”