### PR TITLE
 chore: Update package URLs and digests in linglong.yaml files

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -82,11 +82,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/bzip2_1.0.8-deepin1_arm64.deb
     digest: 5fc6a22a0ad720a1b8fc7f8ef83ddfbb0c59bfa43ad383c7052cf2adf9f3d0d7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-2_arm64.deb
-    digest: 607b0fc3d75acd69911638df7083878e9cf8a6bb5724d7411c44d372747c9464
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-3.1_arm64.deb
+    digest: 7483a0b744f9eac3d46e0744058923d7bef5512e1ff7afa6328ed7208a38d11d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1deepin1_arm64.deb
-    digest: f351814a957e7bf0ec78e2659f15ffd847df8cbcc46dd7f2e1a0818b5a135963
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1+rb1_arm64.deb
+    digest: f50240be45b9eeee8f6d27feb462e5fac2f6aaf88fdd9b50f66606ac044a2409
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2_arm64.deb
     digest: f903e352cfc425eb6e8ac081e2e8df9b0a38977b57e4f945a49c640528f46ccd
@@ -124,14 +124,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_0.0.1.16_arm64.deb
     digest: 9dec686131aacd2b06c42a3b9a571e893874ad818122568de83d3cd97b55829b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.22.1_arm64.deb
-    digest: 870b51bc4263e95f2c124a63d0a021177774d9d543764cf940f2508562b8037c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-common-plugins_6.5.10.6_arm64.deb
+    digest: 6fd1831bd3393e707c33b1928acea17e8fc80516fad8b79f18952a05257a096b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.22.1_arm64.deb
-    digest: 4ee2b36d5d6f115d842e7f04ec407a5f5418d708fa371dd5c36309884498bdd1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-daemon-plugins_6.5.10.6_arm64.deb
+    digest: 87d4d18e1d15964883c5d3e38be7515fe9385c2402a6d525f344db313665d0a5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.22.1_arm64.deb
-    digest: 2fff01a517926dd9b9b2c2cd2316f63d6d8d9bf561ac5301b1c13295e387401b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.10.6_arm64.deb
+    digest: 370d9c201314b119dcceac84465ca18fce52005efd581be19c8a471a4e54497d
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-plugins_6.5.10.6_arm64.deb
+    digest: 2ba7397cef47e5c57166f1be590a07d9c05137e0c990c613d5dfc67c5ca1d1e3
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-preview_6.5.10.6_arm64.deb
+    digest: 0547dbd6dfc8c0694f5143300bbc789398e9036e8a6a1f37d53350105e69f3f1
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.10.6_arm64.deb
+    digest: 5b692b982d02affbfa8766625d0464897f12671962a702bef8ca3d68fa2ea3b4
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.10.6_arm64.deb
+    digest: 7e71414f79672851b01a0241b5dcae9bc126ff7958c28ba7d3666e692dcab157
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
@@ -145,8 +157,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/desktop-file-utils/desktop-file-utils_0.26-deepin_arm64.deb
     digest: 6e1b40ec986b3d9615bc63779c4898978dcd2d9b770c866e86cbaf2ab2b5037c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/dirmngr_2.2.43-8_arm64.deb
-    digest: c818270270e920a299e90c2235c5caa5742b6e867c4cee20d26f29f61fabba20
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/dirmngr_2.4.5-2_arm64.deb
+    digest: df5cb4feb19c5037ddac50f250af69e4106dd9de5f8a71e517f8f3644e296943
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/dmsetup_1.02.201-1_arm64.deb
     digest: 70a943b93efa2735c5b2584e0c473ac2b66bf981ed8c5e323cdd77adaa55551b
@@ -205,8 +217,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_arm64.deb
     digest: 4663b703fa834002da6bbd91431eeddad3eb2f235100782fb3cea7473afce618
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin5_arm64.deb
-    digest: 283465614792edebda370efdf4f2757b8de217ae1e5e55e3450429303c0ad4d1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin7_arm64.deb
+    digest: ae48dfb55b4f7653a2409cb337444b659000347294637d75b6d3771e755c363a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-common_2.78.0-1_all.deb
     digest: 94bfaef9228159f8a2f366b9962e5bd82c9ddb53228b161d62c6f5d48ecf1c3c
@@ -217,26 +229,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking_2.78.0-1_arm64.deb
     digest: 71a35d0dcc2e793ab413991cf7fead4c725ff13a77e2d8502c6d21d28b01b40c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg-l10n_2.2.43-8_all.deb
-    digest: 9c7d9c4452b94dede463c7f748a0dca699bc03a94a5167ba6856c2f10b49bb8e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg-l10n_2.4.5-2_all.deb
+    digest: c9e04d548f5db44bf2772cac43a1fae57f0711e9ab939d0b8eaefa284f50df0f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg_2.2.43-8_all.deb
-    digest: a8ddd90a1334b1814cca606ce19911bbd222a49b1b99ee3c58ca91d819251a20
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg_2.4.5-2_all.deb
+    digest: eaa96043881596b22aef5933bdc2f096163e24f0e12a8cdb4825f6ba8ab6e96f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/googletest_1.12.1-0.2_all.deb
     digest: 2df57ce8c5c8fdc37e1dbbe302d276f1cb9a784df5dd3423208f87933cfa28a0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg-agent_2.2.43-8_arm64.deb
-    digest: 62d5ab10ca11c126be5a3cd218e3e14668bd55f2bfa52ab306617a72404e41d6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg-agent_2.4.5-2_arm64.deb
+    digest: 1190d79a925949852dafadcfc721ec600255a479936f16ee6fd324d31a982ba3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg_2.2.43-8_arm64.deb
-    digest: e35d6a5ee3b0fdeef0f069e60c360eec7479c4c68e7b5100d7c03d4b50c6e974
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg_2.4.5-2_arm64.deb
+    digest: e322c456592bedab0c6fe56effafd9547d3e65c083d948695f1f1e1e3449924c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgconf_2.2.43-8_arm64.deb
-    digest: 6852894d49df437bd156afd86e8b607bbbde9fd55b7d6b11643a2908f7ad0ccf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgconf_2.4.5-2_arm64.deb
+    digest: dcb5b31efdc5f0ad0bdacd34cb8921422c457173d8e1ff9be4386fc678554ab4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgsm_2.2.43-8_arm64.deb
-    digest: 9073fa5bec228139ccda430ebc3bc96793cd84c839d0c619817d070c38a312db
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgsm_2.4.5-2_arm64.deb
+    digest: 0a0c54a3a105acab35f72efe3ff939075a22f70af53c88fb4ab5c71e40a6d84b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-desktop-schemas/gsettings-desktop-schemas_47.1-1_all.deb
     digest: f87ebb3a3d4d6557f779dd83909a6aa79282e7085aacf756fcc828bae36526eb
@@ -256,11 +268,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gvfs/gvfs_1.54.2-2deepin1_arm64.deb
     digest: 491735ab513eb73a1a08e8a02da3f726ffa54e7aa636b426264b99824f05c8fc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/hello/hello_2.10-2_arm64.deb
-    digest: 305f41ce8a0e654a60ceb9433c21516c5570d0c0b297524906d0361b63a0630e
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
     digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/keyboxd_2.4.5-2_arm64.deb
+    digest: 7d24bd64d15c6c73178cf4f56f4f85640187dce3214d2017eadfbaf17b0db009
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/abseil/libabsl20220623_20220623.1-3_arm64.deb
+    digest: 4e7d08584337a95ccbb5167513fa590d5fe4614eb17860b743e190a49bdf9541
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-1_arm64.deb
     digest: 51808064361bdae539f985645eaee59b53c703b293174f761d996b27f2b8d860
@@ -278,7 +293,7 @@ sources:
     digest: 4990cab9125078d6b8ef1caaeabb597ecda80949d02d251903fd496272f59fbf
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/alsa-lib/libasound2_1.2.12-1deepin1_arm64.deb
-    digest: cbd3fec34b226ebef050656d809ae1ff908aee4b97d0f1ec04663c10264bb6fc
+    digest: c6fcbfd312ce95f663f002d524ef94ce632c01610df801b64f459d5c7ef513e3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libass/libass9_0.15.2-1_arm64.deb
     digest: f5fb080fb946561c37bc11f0fca6fa0c0231c6506c0e05c19e60b0ea2f3c61b7
@@ -340,11 +355,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lapack/libblas3_3.11.0-2_arm64.deb
     digest: 3443bb4ac1a9dad808977f7f9e712efc54395f408a054a3f838b37a84f2742bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin3_arm64.deb
-    digest: 25d30b385b80b1b9e62adbf39528c0209c9ab35ad55a071efde1c4dd4d4264e0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_arm64.deb
+    digest: 70ce30db93ccf7870f384aee1946b51da113cf55c7b046c443e8627d35cf73c9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid1_2.40.4-3deepin3_arm64.deb
-    digest: fc30a62923533d0aa445161290f79dbc25c93085e4d26a7cab2ad9d3e1eabd41
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_arm64.deb
+    digest: 4bcb4a5b87eb5953643d6afbe829641df4d4f68a3fbecd978c6f5e3e61c6dc6c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto2_2.26-1deepin_arm64.deb
     digest: 3c8466f6738646d0c955b1aca4d81febacf40f6448e8dfba4439ab381882649e
@@ -427,14 +442,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_arm64.deb
     digest: 502bf30d0f5d2a06d33495526cb4f5f7929623e87ed3c716aafb91f29565c1c3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc-dev-bin_2.38-6deepin10_arm64.deb
-    digest: ec3a0e2b73b855bdfafdd78d22d6e9aa5bb47aeb0eb3861b61c9f83a6f9897ba
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_arm64.deb
+    digest: 6a0003821a9d50b196b9b9f38a5f1f60de910ac24d61208b457cdf3707e66f2c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6-dev_2.38-6deepin10_arm64.deb
-    digest: 3044c810957301e07532d224cff93422fdc1176b8d91b5a342522c44c57b3498
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_arm64.deb
+    digest: 4c44dbb55a5c867b1116eb01c650066512ccd958d2eab84fda139250c8c5f65d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin10_arm64.deb
-    digest: 666ce0302171f939a38c2cd8c94e808893a87aea9f4d05af9a787e4c2b33be94
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_arm64.deb
+    digest: 2421a632cc90d03e652d8cddf07b614505a981adf16e40dc177b832b3d3892ca
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcaca/libcaca0_0.99.beta20-4deepin0_arm64.deb
     digest: 7fbb0df37f497963ad3df913d47a8a7c425fff7a0fb989ca60add2130d4f697b
@@ -499,17 +514,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_arm64.deb
     digest: bab638b4aed73a4a9420a17ec27f3120ff10404c3d3e6e1a66fe023fa8a44121
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_arm64.deb
-    digest: a72f4563335d016cf4a0f8bbf5d26b0ed90f554a8ff2e6b9701967daa114569b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_arm64.deb
+    digest: 1557184d0ba255ee05b5c929396c4c925e10782f9cba74f3514f96d3bf581ca1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_arm64.deb
-    digest: 534a9ba35f69f93d103edbe1736a7ffe7f2b84a8e3746889d78feadfaa507d22
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin1_arm64.deb
+    digest: e9754a238fed47dac0e3e6255697563494f6ca4b58313bc7f6183d4d0995d32f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_arm64.deb
-    digest: 01509b9730896972e09e937a3d27ae4c9cea9b536b0296db37af464314490934
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_arm64.deb
+    digest: d0a1e93cb1b63e0040b50c924c8a7c9464494ef3547447913584d0a62999590a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_arm64.deb
-    digest: 24db7f1a3f57d436a532a215e32df71a9df3ff19731d81c7988c0d77df86b692
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_arm64.deb
+    digest: 12003d3e5acd0a1c379f81e075b6171fb784666763813528fd18189beea9735d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_arm64.deb
     digest: 4fcab53e5e791e65cd9160e0e77eacec106bce0f5ea0567bcb1387b362101488
@@ -535,14 +550,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/libdconf1_0.40.0-2_arm64.deb
     digest: 57f0d64bf483877f4c8e4bec0eaec73227d30795dba37aa6ce726b6816c0abef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.22.1_arm64.deb
-    digest: 1b62300d9f435c51b47221d3c6fc71398c3be00610885ad0409fcd76ba43484a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.10.6_arm64.deb
+    digest: 2c9332350d57f08920935287dd86aac5e9c089607a9f223e7ea7697e1605b70c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cdebconf/libdebconfclient0_0.271_arm64.deb
     digest: 1d9347b2ceba10b302d2c571bfbda6567f159d546a14e99e300a07c2dbe1fb94
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdecor-0/libdecor-0-0_0.1.1-2deepin0_arm64.deb
-    digest: 0e7a786cfe249c8784179530ab4c4e22ccda599eff8a52f326f9698223763fb4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdecor-0/libdecor-0-0_0.2.2-2_arm64.deb
+    digest: f99b185a88446c1b1e4607d2c5eb79ccac6965174ad540a28e4d6ea572378740
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-pdfium/libdeepin-pdfium_1.0.2+rb1_arm64.deb
     digest: 142edb9aad7713d97a16acf694f33905f3fb2dfe20d3bc8571d7755e0ec86a4f
@@ -556,41 +571,41 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_arm64.deb
     digest: c323c31508b8e23cc1b44a3a45920288f17d6cb3a6ae7d53746a3bb2a9a982a1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn-dev_1.3.8_arm64.deb
-    digest: fce84eef35fe859295faa41af74d50e9d9a18fa562383cfe4747cd16208f2f8b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn-dev_1.3.4_arm64.deb
+    digest: ccf577cceee876556757c8680cbb45d74667212891d1a83ba5a7c0a56ab1d50d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn_1.3.8_arm64.deb
-    digest: 2834f67b836387c8f4749f9b232aa353bd6941c26a3c46517f15689c9a05a04d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn_1.3.4_arm64.deb
+    digest: 035457006627e6bf449a714ca000787a1e1441c8434808288c344d8afb0db3cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.22.1_arm64.deb
-    digest: f87b233d91fd078a271ab25cfbf1e42f1b6bc64d4b9474a788a78c3775464c86
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.10.6_arm64.deb
+    digest: f32307c6bc7971ce992f333f499c0a3831538e657583d2f48942e129ae28833c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io-dev_1.3.8_arm64.deb
-    digest: 332252e813a1409a60ceef3e05995560adfe4aacf95b1f1cc459762706576e0e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io-dev_1.3.4_arm64.deb
+    digest: c64e20bce86727c5f20bed5b948305d298d94d957a0dbfa01594efe756f0452b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io_1.3.8_arm64.deb
-    digest: 4ca79734209299e5ac798e73b5f791aa15383014fe7b346285c3cbb0437e5e77
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io_1.3.4_arm64.deb
+    digest: 329851fe9b94e65e6bf7e7fe89305977b7b8ce41d7518725add362ed4f42fa7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount-dev_1.3.8_arm64.deb
-    digest: f8f009a3a0e962398fd4e16bbd26d227cf9753d13adc991f22c470bfa6ca796c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount-dev_1.3.4_arm64.deb
+    digest: 013dd9b04293671f6bd779ecf3b63e3ddef0517b1d3f61fe026b61793fe34d63
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount_1.3.8_arm64.deb
-    digest: ada318df229c1a1fdc4e098020d96f9201117492a4ac962807cc2caf1e465e9d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount_1.3.4_arm64.deb
+    digest: 82b69fa13d4c57cacce14463e1fbef27d789b7224afafe4f9ab0ebbba3a576bb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.8_arm64.deb
-    digest: af6ae52835bbd7b2ebc641032ea5fffb8c2c49c6ff59315d98684abff0d0e38b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.4_arm64.deb
+    digest: 03619a4f69f622b42f1a4957e6351791e037a4bd28022e9ded1db4df84231beb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.8_arm64.deb
-    digest: d0859a43e84d8e00d7e9e2b8840fc7cb69431c962049f450a1dcf4287f898493
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.4_arm64.deb
+    digest: b15fb7824472e89cfb9112af574ec9ae1aea8e015708d6035d33bf593a5b4626
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.8_arm64.deb
-    digest: 4266203bfd55262c068ef3801478d8ee6e35c3d84ba49d9665d68d89ffeb246c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.4_arm64.deb
+    digest: f182df83fe3654a2c0bef8fbf2e478c47dcaad73805593101421fb2ad0a806ed
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.0.11_arm64.deb
-    digest: e641f292d43fd5cab1a2d06362d67cdc0fc404d6da58cfe19c1376d5f0c05203
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.0.13-2_arm64.deb
+    digest: f4ba9f358ff3e3a6c76f4c036739cdd90c5ce9bf74e34a8210bc9becc4b7ee98
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.12_arm64.deb
-    digest: 9e037356c2563471936a2f83973508802741ec0985cf4363c9e76bef703a7e41
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.10_arm64.deb
+    digest: d6c3d26e5203476f36a47dc8d108d9181aef75073e8398acc60ea8072db88456
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
     digest: 78e9245e377c8f61009cc60d2b55001aaddd7b656fceb916b3ba8f07344251b7
@@ -610,17 +625,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_arm64.deb
     digest: 6c900feb79b1e5f847a5b9f53c6bda3f6aa12a9abfcf106f872a3812ef78bbc4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.29_arm64.deb
-    digest: 77f5dee749f1e7955dea95fc487386dac51f9847c2fee14df006d5ff058b7aee
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.25_arm64.deb
+    digest: b8693fdd024188f811597e28d7d7e03dba17e811711883716b7ff76376801e02
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.29_arm64.deb
-    digest: 18e09752cf4ba9f7f43b911028cb0b5c6a8294fc1b5421da318fa948a23e82d0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.25_arm64.deb
+    digest: 3442eb4010d5176f27e5062d6fb07f1d8afca80c59375f9c37aa65eea62a727c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.29_arm64.deb
-    digest: 223410c6c626e2e33f90a628108767ed1a0a1b52d623c03a1c415511f3302604
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_arm64.deb
+    digest: 5b30d2ade934bf6b80f4fd6e9eecf7549d44e9df70c8e97266b720811c90ffb3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.29_arm64.deb
-    digest: cb34b440aa67a9476150afb1452a5b08bfee72a7eaf115e0de34ee913432d5e9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.25_arm64.deb
+    digest: 34a82a6a255c9d9ea99e12432c047cf0efafd61101a90ef319689d4940fa9767
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.2_arm64.deb
     digest: 0e714a576b19f5a920d224ef1a1877e93c4b8aea1e49eba99df7316c72319910
@@ -628,29 +643,29 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.2_arm64.deb
     digest: 67e687906a183922d6e510666f7637c45946e68f61bc4f0ce7fc2a840aaff3e0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.29_arm64.deb
-    digest: b408e3a489240d24e0ae01db0d5e676836f1079a30ab0157f56eae45e01f702e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_arm64.deb
+    digest: d77647f1b8ddc312041ad612cf3c1343bd3fbd8193b2a72e8bfae9ba64d4053b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.29_arm64.deb
-    digest: aca85a4792640c434775c9d23fa975c7961f57c609eacc0b95f4856007a61408
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.25_arm64.deb
+    digest: 146b21a131932f6ced35c1b74c912ae9794b9bdadbdceff37babece4c9eb90bb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.9_arm64.deb
-    digest: 9228e408fc7bd0ba5facb59e6144b837aa991a38fc2f8dcf7464265c1398583a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_arm64.deb
+    digest: 11cf667515ce2bcbc7ac6ae27bafc324f6cea17772d8e7aa43cfda6288713e67
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcore/libdtkcore5_5.7.9_arm64.deb
-    digest: afc486a04975c5732f8063c331d383a1732ff9ce5f5e6eba5934cd9caf224057
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcore/libdtkcore5_5.7.5_arm64.deb
+    digest: 5c0d695b2d9c3190db589a7a84986f7dcd9ee54dd7b74eb1b592118d9a6fd052
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.9_arm64.deb
-    digest: 3599ea894d347be8031fc5bda86750ca86d9c6d4ede8812bbd7b225ef7499e32
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.5_arm64.deb
+    digest: b468b48c1f8fe5b98f4294edbe3b757726fcefbfdfb79ab54d3adffc293d17cb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkgui/libdtkgui5_5.7.9_arm64.deb
-    digest: 620939fa922f6f51942b7cb1c7b63616ff626e6814e0c7858e17197f437f3710
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkgui/libdtkgui5_5.7.5_arm64.deb
+    digest: 75c83e7d6e5c2fe51ef8342b3532f487abe60f0163cdc6c3a9a675a08abbfb4b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtklog/libdtklog_0.0.2_arm64.deb
     digest: 44c162ceeff309bd16de1684f8acfbda08b8ed9607cd989813e91fb945af0d5b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkwidget/libdtkwidget5_5.7.9_arm64.deb
-    digest: b8c318c64cae01333533e472dc466881dc4becba7a2579762bda96943d9d790a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkwidget/libdtkwidget5_5.7.5_arm64.deb
+    digest: 0bb6d99f853f3c4b37f76c992d8482a950b4e32eb365e1283f41ffeb9092952a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdvdnav/libdvdnav4_6.1.1-1_arm64.deb
     digest: f5e805b74f43e619521c8d270fd6cc234a231bb0bfd15d3c626dc5653b28fff6
@@ -688,8 +703,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libext2fs2_1.47.0-2deepin1_arm64.deb
     digest: e8929ce0ede640e5ef66a7d194161fc4e7f256c97e17a77e31bf12421810dd7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libfdisk1_2.40.4-3deepin3_arm64.deb
-    digest: fcf64b2a288dbd7cd717eb9caa9d209a489aa0e21046aeadb2d136977724103e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libfdisk1_2.40.4-3deepin4_arm64.deb
+    digest: a65b50a99754b99ce6ced8e3738a20eb14561964b29285eeefa9eb84d71314db
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi-dev_3.4.6-1_arm64.deb
     digest: 44b6f1a9aceead0cac121cfd13cdd9a529eb2b60522f8482c7dc4f67432d1904
@@ -880,8 +895,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_arm64.deb
     digest: bf8f6e987ba71ddd6161066f0828663b4ffc4af78acbdbff04b71e5c2b1e207f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-qt/libgsettings-qt1_0.2-4_arm64.deb
-    digest: fd999a7223fce87dd9552252c0bab5a9d58b105663377d743332ccfdc029c112
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-qt/libgsettings-qt1_1.0.0-2deepin1_arm64.deb
+    digest: 418114289f248c33a0200dbc60769b2b9c040f47d8bf0ade4c998db0969a37df
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgsm/libgsm1_1.0.18-2_arm64.deb
     digest: 433078cb4127d8b89dbeaec5ba11ada27bb88ffb3e6a23bbfb882fe6e6a253f8
@@ -1081,11 +1096,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_arm64.deb
     digest: 15763cf880b4073ba036e05f2a3b9b46aa43802f9d2c49848fd315a9229d9be8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin3_arm64.deb
-    digest: 144f52c28a6d1d379a87413988586b9570a7de5a3ee780377e5ccc02f1d671b7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_arm64.deb
+    digest: 62f3c994934747f7cb43813a34b1090787d0f7471d4c1f0607b2ad476f5f7105
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin3_arm64.deb
-    digest: e6955743fd652581c76db11ec14490be887549666f150765f50a66e0a8e43075
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_arm64.deb
+    digest: ef3494fcc16550aa223cffc70e189fa2355dd5bcebc8b78dc303250063cd7dae
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lame/libmp3lame0_3.100-6_arm64.deb
     digest: 3362ecfa4b431c335a8833e3c5014f24ea43d6f1f398831c48fa03c2234f7059
@@ -1240,14 +1255,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre3/libpcre3_8.39-13deepin0_arm64.deb
     digest: 4c97742578bdf73cbe239ca5a1a878b656583841ee388b2a4b9139dcf9508e11
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10_arm64.deb
-    digest: efe41ac688ac3c99eb41a36854ac9883e877d0b5f0a52a844b752ded579ebc57
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_arm64.deb
+    digest: 0845846b66b31eedd72c968130416fd011806d63c87506237ef08fa765edfc28
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
     digest: f09601fbb60184cf2257b12a7eec5e39ae0d8659ae517bb42de686abc791f5a4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin9_arm64.deb
-    digest: 6d2dae51eeb4997b07bd115ec79d452b22f3d2879f4f5946325fcb6a12e50fac
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin10_arm64.deb
+    digest: 8c5840595cd53c664c6439dfb45bb57f3d181c60d5825c305835909b0ed3eb19
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pixman/libpixman-1-0_0.42.2-1_arm64.deb
     digest: 7195e91186e69bd55b9c05269973f6351a3a09470ce297610cf3d22ef6cac45e
@@ -1270,11 +1285,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_arm64.deb
     digest: 9523527a9becdf223c0c367aaaa04cb9db76cac405316314ee5216f991384fb5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_arm64.deb
-    digest: b97403d9f18a9f81f3b2f39f8d7bf458e6667f228759ab104824be390dc7c291
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin6_arm64.deb
+    digest: 145c1faeb428c003d1c00e22c25b4ed3610f3e51b26859d144f2e4590ca935d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_arm64.deb
-    digest: 925c8a5c655f77618d9b764053fc51eaf5cb61dbf499c2655be89e2da21654c4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin6_arm64.deb
+    digest: 4cad261fc851c6e8d4c4f56fcf3c7845c9c5cb628580b8d720166dd4cd0cde86
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt5-1-1_0.200.0-4deepin1_arm64.deb
     digest: 82abf807bd749f8366d50e77168da7c99a7712fe6f6441371840767e8377a89c
@@ -1303,8 +1318,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pugixml/libpugixml1v5_1.12.1-1_arm64.deb
     digest: 33918e1f4c4e4a41bd2d726f4aa47b8108c838500da00dd8d88eb5508f7acdb0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse0_16.1+dfsg1-5.1deepin1_arm64.deb
-    digest: 90867fcf545872e7a1818b2fe4892e7a12eaa166e14f990df2eb41126d992401
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse0_17.0+dfsg1-2deepin1_arm64.deb
+    digest: d5550a99b5654f86e4bfd43dfcc60574a1dbc606897f0edf5657edb0ab20c6d4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_arm64.deb
     digest: 94be53c10a1ed8538483d1dbd426700ff5a79ffffc7632c3a3eee0cd9ba2e869
@@ -1363,14 +1378,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5xml5_5.15.8-1+deepin9+rb1_arm64.deb
     digest: 90507a5f456438e1b79ba5d0db687abaa29727102aa46c7fe3397d378962a565
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 2e5bc78c8d20e4a71ca86f5028792ef121839e3cb843cb563cf06c9b6564a7dd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 4487ef000bab280d24e5796107f266dbcc7bd98da9107fa46622ec2466c7b16e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 45dc13bd5153909a5212ffb9fe190be095e305a071631dbcb34b59bd03da4328
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 8e79cc85474e16b11086c3943e9f68ba2980cd02c25126441d5787a9cac9f126
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: c666ae371592527f7bc8d20a2ac02c4539e3f306a125400465a00d1b55a5148f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 7b23577876590b68e561e40905d17bdd102d05ec005bd3f3aa02085435f729c5
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
     digest: 82c28b84f82cbf7e3d9098c0f856b955e811a65b1fd42c8515711aecd05fb894
@@ -1378,23 +1393,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
     digest: c183e82838d5b340b4273253e90667078512862e1f8e9781b72b7ce048bf54d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 53967844b2eda30ed1c7883a0ebf14c0ecfcf5d70a8f0e545bcc2195c57b7a1d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: fbc7604f9d54ffef67fac1b67eed229d14ca15d06a45984e316768b7c63bd930
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
     digest: d725d7423abfc45ea48abf3d9cc444b95af145636802254bb44565f31d4d4245
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 89f138c7563d9fe69d98883154665b6adbc2b69b42d5f1168b1c106fe9ec274f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 34ef8390fb279d048e66d691572247d54ea7e04222db0507c44ac113914c0cd8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: e038039d3aebdaec034b0be5aa2aeac57ab281f326bea09cb4c1baa76e5f0cd5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 2280d74bd82b5e9d3a065c9acaeedc7d9f3c222517588c7777a62de2b30ff51a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 73c97b64ee7867d65359a0422b8509903c13a1a58e7389fc39b5a4f2fe86412d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: d79ad717b4275bb2dec400e7fa3ae8045c4d93b38fbc5a9c5eece9e9d7d3d14b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 8d46dedea87833ae07a1e47d859772ccd0466f9156a06cefcf9cdb7546721429
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 0a2c121bca7a1b60607aed1855b50fd2c630622bbb2f4b9fe5362a4a187893eb
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 8c18da39ba69ceef945d4c64e3a0e62a1bdcbe2b41921ead0aa08f4cc52c459e
@@ -1414,11 +1429,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 9e46187cdd05eae2b1113623f827e080aa663da7919c1d87b44dbb03792b4dbf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: ec05ab5498040ffe82cedb93bfc9f6e30149fd0706fd1c53452287666c8302f8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 1f084ff72c612db83096eb3dec73f6101af9fe977f3376badf680a07926ccaef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 6fa44cfd008c061afb7ea741f5b714df68e3dc07e54deedc2506e4753df1ee0e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: b8b4da1591cec015ace3dd8953ccca06f19f3430ddfc39faadcc6a65eda21965
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_arm64.deb
     digest: 9902fd043a3e62bba9f7d13edccd49a25d8d17ffa0ec5cdc761dd7a5c0d8b63a
@@ -1426,20 +1441,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_arm64.deb
     digest: 34f386ccca09b000fd6621ede73daa2fac0b94f8fd9af514767a94ed39a15bf7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 0e3a7ed737c3186e321c40e38ffad5413982137644db82b9df9b0a73bc3bba2d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: a69495c011e5db7fd0552ffbe180cfb43640c35271ffe21be3bcf44053ff72b8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
     digest: 75ef6edab7f429e473a3f73bed21049eaa774f3e6333cc583e55b1f6bda9f016
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin4_arm64.deb
-    digest: 5b45baf715d8ee4a73b7e018ab9558efbcfd7e284a6da9082b9d83a0481af8b8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_arm64.deb
+    digest: f4b2cfd1d6b0a4573939eee7d9a48133e1068fb741d0b4ec8dc18889bc24fb8a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 5a230a38b8e1dd86bea7808bed5b73e644172a7cf7a04e0276262e9ca37ff35f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 3f27c16a00798b99ae45f723331d3601e3c3741e6041a0ea4bbaec0ee7873c16
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 3788115be025bdeb64f53fe6b53d78c544ed6aab360f60a871407b64035a2d5a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: e1cdb4a74a5f30c6580796070a19e575e0f6c5f9467c5f1c9561bb113cf66d78
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
     digest: d38dc8bd34b4cf0fe94e16797f662191b91eb9e16f9f0b44bbaaa9b4b4d736f4
@@ -1489,11 +1504,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsecret/libsecret-common_0.21.4-1_all.deb
     digest: 2c12c067604e4872a281ddd17347c2a8bfa35ec65c086d46aed37414786205ab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_arm64.deb
-    digest: 503a2e758120d6eb2225f02eb4f509ed636560c343e42a685b68a74345c7c11d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_arm64.deb
+    digest: aa09e909d7f1ba4c18ed4aac21d5aac26637731dbc0580e01cd76ee3cb8103c0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1_3.5-1deepin2_arm64.deb
-    digest: 9a9a27dec46d935b4ae8318b26d91c347e2adf9d6e7904f4e465c0ccfed535bc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_arm64.deb
+    digest: cb9047fe72aeb8caaf8ffd6d7be6fb0f307df7d382d167aec933327ed83c87b8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsemanage/libsemanage-common_3.5-1deepin1_all.deb
     digest: c4fe4277d3df3d1bbf39083659701e5f4f9857e612ef7f1185e45eedc8f27047
@@ -1540,8 +1555,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsm/libsm6_1.2.3-1_arm64.deb
     digest: 04dcd31830a75668f1114bff0dd08033af565b7f4f05cdb411d101ccff99d6e3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libsmartcols1_2.40.4-3deepin3_arm64.deb
-    digest: 6db8838314739fb1abea49a942b75df9bda3f69c8e5c34f44ef6a68c717e2cd9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libsmartcols1_2.40.4-3deepin4_arm64.deb
+    digest: 85e6146810d7fb13c610809ddf7de0d7747cbd2a85e9939e884bdbc707a4f217
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/samba/libsmbclient_4.19.5+dfsg-1deepin1_arm64.deb
     digest: ddd6faf31bbaf673b189720255eebdb48b4c26705efb1d69ec1be1fdfda2e1b6
@@ -1576,8 +1591,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_arm64.deb
     digest: 57472a0be9bd78ef65aa7f486c6b1236c956798c2af1152d7fd71bcc71d73bd4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin9_arm64.deb
-    digest: 85fa70ac78ef1dafe382aa13932024228fb71c5d0508d87130724dcd8b3b43cf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin10_arm64.deb
+    digest: 6fd9b67263e80bb6785c55e36bc33cf204233450ff6d542ca56106ed4411c334
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
     digest: ffeba610e1f0ffa299499d88562b65eece4f9865d8810d3a6194ff5d2cd02b38
@@ -1687,42 +1702,6 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
     digest: 790a0e469c3b174d03eb0eb64f4a69ddddd95ddfd4b8daf930e4b4ac7cde179b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-mu0_4.0.1-3deepin1_arm64.deb
-    digest: 63c82ff13b6508815102e78c2b5f5fec1aa5124ba83c4d47a5d82f880ab79742
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-rc0_4.0.1-3deepin1_arm64.deb
-    digest: 1cfb976ef394685ba0a5492bedc18183654d2ae83fe7f7c6e5d548c6a41edf4e
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-sys1_4.0.1-3deepin1_arm64.deb
-    digest: 740cecd2c47d3cd217b61d621369ca33c38eef72323ed0c1761d6ab062eab431
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-cmd0_4.0.1-3deepin1_arm64.deb
-    digest: e761d3ecb1cb05db10f73653fa97004ac840a2cdbee425da54cca246a32d6b46
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-device0_4.0.1-3deepin1_arm64.deb
-    digest: bf8c85db75af9339224402937a6e08d1d2cad51672dd8985edb78e5bc12f3c15
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-libtpms0_4.0.1-3deepin1_arm64.deb
-    digest: a5c7519a172163b456cd514252a737b77779d61144f174a13216c1a2ee71aed4
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-mssim0_4.0.1-3deepin1_arm64.deb
-    digest: 1cf754870dcfc41288108ba02eb361691f10fdb108b3a890e552bbbe3e0156ee
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-pcap0_4.0.1-3deepin1_arm64.deb
-    digest: c0728c2e0563765935ee76edc4234696185b3df9dc7022761850bf80b04dbffa
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-spi-helper0_4.0.1-3deepin1_arm64.deb
-    digest: 7b2db9a23af1acc89ecdda7ea91780e4cf51512404d2ec0180400038f1f29c7c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-swtpm0_4.0.1-3deepin1_arm64.deb
-    digest: 460a258ecd76c37c090a6842dee8608aae3fa7338d01b470f4c42568c461bcea
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/libtss2-tcti-tabrmd0_3.0.0-1.1_arm64.deb
-    digest: 218b9b5a91c6644ef503296bf4c40e6600f8d38c55cb96625fef7b56b419f203
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tctildr0_4.0.1-3deepin1_arm64.deb
-    digest: c1dd1676b5cd10be30014d723fc6f913a8474db2274ca45962f04faf77f15b53
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/twolame/libtwolame0_0.4.0-2_arm64.deb
     digest: a247a9281bd98fc91f1a6ad3df03546b2e98885a02a72c8d827ea77558ea3c83
   - kind: file
@@ -1735,11 +1714,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
     digest: 4e25fbdfe08288e6f58cbf5a02a5147f4c2d6f41927020d20cc1a60ce49b5c0c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin5_arm64.deb
-    digest: f939b26214af8b9d83370891ff767929b16cdf17fc54cd1d7d27a20d371d5419
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin7_arm64.deb
+    digest: 96aefdb686dfdbe7d62b948027fffd7b67a306ecd2e39730305b68df42059571
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin5_arm64.deb
-    digest: 9fd66bcffd2327746dbc03689309b0823dc90bcc7a05ec5053ea515cb4b8842f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin7_arm64.deb
+    digest: 4fd7b4a8341418ca3c70c25f8b238c32c23eed2ae947b363e802520f8424b24f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2-qt5/libudisks2-qt5-0_5.0.6-1deepin_arm64.deb
     digest: 99470e8b7b315bdfeb371dd37500350d2181dcb9fbdfa0c6b70beddc764cbc08
@@ -1756,8 +1735,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libusbmuxd/libusbmuxd6_2.0.2-3_arm64.deb
     digest: 084d9c20cbd2822b882812e8f03ce8ae3fa870d630d3b6ce8ca10f9f062a9c07
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin3_arm64.deb
-    digest: 0015f725c4c05cbf917a8572b7f2a6314e9c1ee7c90b20e2d2060ddc9606c6da
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_arm64.deb
+    digest: 35e273e250258aec0345b1fb3659e26fe1c31ca0516e749f5dc663435a993e5f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libv/libva/libva-drm2_2.20.0-2_arm64.deb
     digest: 9a61323993ee5414465bffd67342d3f96932516459f43434b16fb82bd75508b8
@@ -1834,8 +1813,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_arm64.deb
     digest: 5473ae2903e00b0fa112a226da1db479e7ad8006ef170a650a4292704f5d9723
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/webrtc-audio-processing/libwebrtc-audio-processing1_0.3-deepin1_arm64.deb
-    digest: 1c18d9e1432c495d6b932a21c257dec0924c9a70e2fe880f7bae5ae401814939
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/webrtc-audio-processing/libwebrtc-audio-processing-1-3_1.3-3_arm64.deb
+    digest: 1ae7033bd78648f6cb69220ef2bc30d55783ae5c8096c10da396035bc1a4be4b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tcp-wrappers/libwrap0_7.6.q-31_arm64.deb
     digest: c11c2592469fb9d5f7b8a46a8d6110d51b940f55734ff4dfbdc8af415206eb76
@@ -2020,8 +1999,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
     digest: 467675c0f4007bad669a8fefe0ec4ab45f1d356f947afd7aabba2f17b88401fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.18_arm64.deb
-    digest: 305736a76597755356ed54d9b5f36b935702c33ed1e17c8b401b4239e3ff10d2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.22_arm64.deb
+    digest: 6c428b10b15ae8850c7084eee2ba403b7f2ae6106d63fc4fc28de33593cdc626
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shadow/login.defs_4.16.0-7deepin1_all.deb
     digest: abed558f44fdd893df5020fdd787b2ee1b5cbc8b5e4b78ab4b01b8f1cc1aad08
@@ -2047,8 +2026,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/mount_2.40.4-3deepin3_arm64.deb
-    digest: 95e926a52ce42b1502471976d27966f3e1f65e16c02d1e79d01a1ff88e8e1ce9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/mount_2.40.4-3deepin4_arm64.deb
+    digest: 3964535e1eb2c66f8e51e3fb281446679fb4a78df29ad51496d65237156db1f8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
@@ -2065,14 +2044,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/patch/patch_2.7.6-7_arm64.deb
     digest: d69d6e60753f09647125fa0991f7bda438f75c33708a9ca01dd6f1b6b87a3bd7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-base_5.36.0-10_arm64.deb
-    digest: 304683781e224018ad5ded38b86cf929281ced3eb79e456761479b7db9dbf641
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-base_5.36.0-10deepin1_arm64.deb
+    digest: e98e08d6308dadcd156dfe5bb14d8f12ad9bef51804dc6caa6cce6f157dc0f1a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
-    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
+    digest: b79ccae8397e919ee917cd187b8be2d3b10eb598f43cf72a9d9a50c3d81ec288
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl_5.36.0-10_arm64.deb
-    digest: 78c75ef3cfd45150fdae9a88e5fca3d7d5c2b1f4d1ad84fe914a3aa0bccfe77c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl_5.36.0-10deepin1_arm64.deb
+    digest: f4769ff0d6a971a7fc77d5f80e5cf6333da1ad8e2589da461c26c3744e944888
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pinentry/pinentry-curses_1.2.0-2_arm64.deb
     digest: 6f1bd2f453605e6f2847629cad4a87609debe25f9ac1ba2652a343543caf1b94
@@ -2107,11 +2086,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
     digest: 2608678aef17e7c03c4b1fc3f3e8e10b91c7ec523471e4e4cd7790be50ef8a40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 8a4e28e196ac42c8ad3cfdcc1b51590fd756ee97a3626913b47070aa0bb66f17
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 01b961cefebb3c8c0f30ffd65c461f0000340eb4413763f621a42b41418eb905
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 42fe0682acdd6038de3b43d82b0c6860e7051bb6c29a6b087d18254469ef04e6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 3b73805c92b8937fddc76aeaae447efca88be5c4edb906dbe86185adc47da0fb
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 3f2442b73e48918050635d141f1ea8112442ff9217e92bd998bc9155ad201411
@@ -2131,11 +2110,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtimageformats-opensource-src/qt5-image-formats-plugins_5.15.8-1+dde_arm64.deb
     digest: 352b0e2dbe79d73fbb34bdc5fe9282781c8cab65e0136638a1398f36997ec3ea
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: f6304914624ab51e67d01d8a58ed72059997f1a507a44c605968bdf114986e9d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: f1c60c7ab3ec69c9fd52a1d42fe8afdb1555e7e54bca71f417e48908b8868038
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 43c1e0b0cc7debb28a2e63bd66eb5e91ffbf255626fa167a4d825d1adccfc13f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 65ffeb095fc0fb17977dd797bb410d7a401f94e8dfb981813a3e6af39c54b7b2
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
     digest: 719086d3983481e4d78e4c7424a796831db3925c1ca6b3495513e9cde674565b
@@ -2146,8 +2125,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
     digest: 9265848cc3a9da02d8de859a7705604e75d2baef2fc16cd243485e56f15ccf5a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin6_arm64.deb
-    digest: 5010567b525de53d80e9a9cee60cf259407c094e3f34d46b0c8cdf12a558649f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_arm64.deb
+    digest: 87651591e1fd396c4af3a4073c2ae33690e34706110f882a05d984bdd895a2f4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_arm64.deb
     digest: e6732e7d1132d2a84254c8868b2c4cbf36e2afc4db8f82859bd8e5b9f40bbc7c
@@ -2182,9 +2161,6 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-dev_255.2-4deepin6_all.deb
     digest: 41bec4491af5737e55f1c186ec8bd05d24611dfaeda7132354e75ccb6ea7dd68
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-standalone-sysusers_255.2-4deepin6_arm64.deb
-    digest: a86ca66d7a15c36ed3f4cacda6d7804315ace461760acd60e2ae2d6a7012c2ca
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-sysv_255.2-4deepin6_arm64.deb
     digest: 9e85eb2e2e36dbf8d2d9e8ae1579288685ae0341695e0793f2b60238bea21f9c
   - kind: file
@@ -2193,12 +2169,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb
     digest: 9e736851d33ca49a6e7ae4b188c480ea0929cb8e322da77174570c64a1037175
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm-udev/tpm-udev_0.5_all.deb
-    digest: 8305c01b236dc4838bfd5f3331c403ed344207b35808d4bbb76dd58471a65b60
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/tpm2-abrmd_3.0.0-1.1_arm64.deb
-    digest: 5210ae2929577246c7cb3bdcc8ddf6d2297175c7e5b4b15bde623f0358eebe75
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
@@ -2209,17 +2179,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/udev_255.2-4deepin6_arm64.deb
     digest: c3ac0170c5d0dbac30342ed985bec90bcf496d17a658febea9ff13b668ee15c0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin5_arm64.deb
-    digest: 1720f5c0ec068c327abc8f97a54d572a881daf97d982b04577b801685c482eb4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin7_arm64.deb
+    digest: 2cdb96c3cbf83628892fbf6f8ba48d78fc776b03b803214947195c6f36193eff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usr-is-merged_38_all.deb
-    digest: a955d8f015290e7447210d049a362e3f04afcb82fcf1f0b4403d13df7b4f5fd6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usr-is-merged_39+nmu2deepin1_all.deb
+    digest: e8896ae20e16a3b4ab0ab4caaadf884de1c0056ff449f85ff1426415e8758a3c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usrmerge_38_all.deb
-    digest: fdc636985788b18a04cd15941a111fb2a73d3b56cf58c689b918345e6f003161
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin3_arm64.deb
-    digest: cf689b83b763f787cd1230760a5dc5b3eb24f58c23552291d11030a753253801
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_arm64.deb
+    digest: 079ee6193e894d85bdb6c51b4318514bf0f788c12560b7bd05b46d6f12df388a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
     digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49

--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.19.1
+  version: 6.5.20.1
   kind: app
   description: |
     font manager for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.20) unstable; urgency=medium
+
+  * chore: Update package URLs and digests in linglong.yaml files
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 02 Jul 2025 10:44:50 +0800
+
 deepin-font-manager (6.5.19) unstable; urgency=medium
 
   * chore: New version 6.5.19.

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -79,11 +79,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/bzip2_1.0.8-deepin1_amd64.deb
     digest: a67b553f354a824475090fcd7a1b6fe237598a1445158526027f2970aa976def
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-2_amd64.deb
-    digest: 7db3ca4c87fbc503778b5bf558bd41b315ae5335a9f034ebbb97e61a546d235a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-3.1_amd64.deb
+    digest: fe25e3ea5c363bb1235b3c52812647b06c7fdf94018a0f21dbc5b8c5817701e1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1deepin1_amd64.deb
-    digest: 85a8bbb77f5ec1ccc03fdc95b907fa4807902b1e987be82f74ba559993b2c510
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1+rb1_amd64.deb
+    digest: bb725bb6b5628391b35c88496a1f793a1b19220024631d0c2e7444206020ce44
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2_amd64.deb
     digest: a82b85f523398f8f0c8773ae390bda2c3f13988f9e863bb26fd4fe5479f61492
@@ -121,14 +121,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_0.0.1.16_amd64.deb
     digest: f60dc0a5a35636cb5a64b26954429a310d1064b3d7a94e562721638eb696e5dd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.22.1_amd64.deb
-    digest: ab29a4fe24075979db0cbc7492540f58dbe201a58233d7c55aeafbc1bc8b59a6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-common-plugins_6.5.10.6_amd64.deb
+    digest: ef0cb97201bd4a402e43ba65b74d3407bd146c9b2934c95a91e43def0c21cc92
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.22.1_amd64.deb
-    digest: b9895a9b77b1a93542e5c034aad8923c77037b74ce09998cf2a6d4bca1b05fbb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-daemon-plugins_6.5.10.6_amd64.deb
+    digest: 98c2470aa6751d30a6f742e16278d6b36f5ad6c0214e8feef0e1a51aec4d0e97
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.22.1_amd64.deb
-    digest: bdaa6f8fff41fe6c69dbcaa0c72bca412f3908ac26c17c44fbc3b9136f0e48b5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.10.6_amd64.deb
+    digest: 7e44139df982f6e77a3915de78fb0e07908698273802e6ca60507851fb1adbe5
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-plugins_6.5.10.6_amd64.deb
+    digest: b3e385782a9b3aef5a87229ef658ef664fe31a32de92ed211e63dbfc7e650221
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-preview_6.5.10.6_amd64.deb
+    digest: df0918f0290c007ce2449390fbb8112377e6386174ce1572fc803a13ec59d9ba
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.10.6_amd64.deb
+    digest: 7d57a57dd13ccbe2d11598bd2b980e562359b1adb6d3527ff0b91eb1e4fda900
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.10.6_amd64.deb
+    digest: 72a2d94b999bf78c9f66c896caec29bbe10dd403e1fe017e6b48dd4af3fe3f3a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
@@ -142,8 +154,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/desktop-file-utils/desktop-file-utils_0.26-deepin_amd64.deb
     digest: 9c27ad7ca2d1fcba24a10119a2beae8010d96c4666d632a0787aaa22410f50ed
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/dirmngr_2.2.43-8_amd64.deb
-    digest: 31457f77e00c80e2bfe3c04703e7790dc8ac70f9f4211eefdab46fa671bac75b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/dirmngr_2.4.5-2_amd64.deb
+    digest: 56416fa6d0103f9c985fa0a81561d36ef1f4b33a801aaef21a96c07f3a213f26
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dmidecode/dmidecode_3.3.1-deepin_amd64.deb
     digest: b130c1f3a9082eb348ca0dcd5c0a6ce4787b41c720b9cf26561ec46e43d203d9
@@ -205,8 +217,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_amd64.deb
     digest: 101c6cc50091fefd708f98e3a9cbb3b8e6a6cb93d52bb45537c13ee0fa5e1678
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin5_amd64.deb
-    digest: 600ea102abfce203ec7b6aceec6b0348f55783e51d22a4dff488c3ae6e798e08
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin7_amd64.deb
+    digest: bf28fb406d0adc929c38f75824cf1e029cb1e830c9367accb967b11a3bdc1b42
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-common_2.78.0-1_all.deb
     digest: 94bfaef9228159f8a2f366b9962e5bd82c9ddb53228b161d62c6f5d48ecf1c3c
@@ -217,26 +229,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking_2.78.0-1_amd64.deb
     digest: 3becf1edd62d0fec815062fb84cf821dea5801f946e5191bab534e5d28f8d1d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg-l10n_2.2.43-8_all.deb
-    digest: 9c7d9c4452b94dede463c7f748a0dca699bc03a94a5167ba6856c2f10b49bb8e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg-l10n_2.4.5-2_all.deb
+    digest: c9e04d548f5db44bf2772cac43a1fae57f0711e9ab939d0b8eaefa284f50df0f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg_2.2.43-8_all.deb
-    digest: a8ddd90a1334b1814cca606ce19911bbd222a49b1b99ee3c58ca91d819251a20
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg_2.4.5-2_all.deb
+    digest: eaa96043881596b22aef5933bdc2f096163e24f0e12a8cdb4825f6ba8ab6e96f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/googletest_1.12.1-0.2_all.deb
     digest: 2df57ce8c5c8fdc37e1dbbe302d276f1cb9a784df5dd3423208f87933cfa28a0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg-agent_2.2.43-8_amd64.deb
-    digest: 631e289ca136590b21a619bf150e0fe7282ba8a09fe53a1f395424a63ac14448
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg-agent_2.4.5-2_amd64.deb
+    digest: 484cc5be26ef292ea0de9f2a01f638bf2058dacb92acb95b880d039a5abd880b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg_2.2.43-8_amd64.deb
-    digest: ef5aaf62e26312bd1858eb6ded8a5cdeb61ed75f23e8b67fe662546b255140c3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg_2.4.5-2_amd64.deb
+    digest: d745ba105a9c2b2b343f655d66a9b4e89f37ab061c5ec3828332fde8b3176500
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgconf_2.2.43-8_amd64.deb
-    digest: 308ea480a5f5d69c38db2cb64a2abf7856c02cf52ebf6a4fd51dc268b8fd66c2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgconf_2.4.5-2_amd64.deb
+    digest: e6d235369314f9aee3b51ac8a52f9dfd4f618f1e4e670694c3d24089ce550680
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgsm_2.2.43-8_amd64.deb
-    digest: 325472d6d5968dc1665dd31522fdb47765f4e42cfc4335334eda9217a4cf08d4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgsm_2.4.5-2_amd64.deb
+    digest: f8919bc0b4b356f2b5165536217c0fe741ffdb148d1641bb08ff76a3e0e5c199
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-desktop-schemas/gsettings-desktop-schemas_47.1-1_all.deb
     digest: f87ebb3a3d4d6557f779dd83909a6aa79282e7085aacf756fcc828bae36526eb
@@ -256,11 +268,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gvfs/gvfs_1.54.2-2deepin1_amd64.deb
     digest: c3b464971b5a0737f8d2aed504a0c358df6a50634472eb0afb1bffac336cb0f2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/hello/hello_2.10-2_amd64.deb
-    digest: 419bf263fc5c36903f07f03dfe62e5365163e52ebc1beb717867b5c7aeb47bf2
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
     digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/keyboxd_2.4.5-2_amd64.deb
+    digest: 4c24beb848d7a567609da99bcca6f5c6969db44a143dea535b9d1b1a975e9c62
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/abseil/libabsl20220623_20220623.1-3_amd64.deb
+    digest: 23ce45fe62610dd94dd8df7f0237509622e65c12334ea84d21ceaefc901d195a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-1_amd64.deb
     digest: f06e936eb913b8e9271c17e6d8b94d9e4f0aa558d7debdc324c9484908ee8dc8
@@ -278,7 +293,7 @@ sources:
     digest: 4990cab9125078d6b8ef1caaeabb597ecda80949d02d251903fd496272f59fbf
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/alsa-lib/libasound2_1.2.12-1deepin1_amd64.deb
-    digest: b67346ecc0e5a1996e3325d9e005fe489f87d7989ec122ad56af81da8cc6bbd6
+    digest: 13c36d1ba89268f03f75be93ec321e393f377421f6867bfc22f243be102460b3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libass/libass9_0.15.2-1_amd64.deb
     digest: 1c0c5c27e1ae950841911d144b4e3cd319ff90177e3dc046367585c7e6c88ab6
@@ -340,11 +355,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lapack/libblas3_3.11.0-2_amd64.deb
     digest: 4593968beae667f8d58b700e63c047f3f0ecab70482cd4696246ded9ae7294ac
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin3_amd64.deb
-    digest: ddeee755de43b7c2bbd22561e4a08f8d640941759e0ba5aa5f67b42fa29aa7af
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_amd64.deb
+    digest: a4d108ebdc3c5710be943be9fc8b480e7db0704da63fb2c041dc2865df4ce4f9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid1_2.40.4-3deepin3_amd64.deb
-    digest: 5858a393cfc2bd7c4ae1be81d804992278605ae5f6c3b52c5bc2300f89141af9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_amd64.deb
+    digest: 567b0f1dfc7844c74fcca08a18d6f0d527caf16278e205095522a0454ca23918
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto2_2.26-1deepin_amd64.deb
     digest: 1bcad2d41d17d258ec2ecba235be7e8c18c50c0eaf1e9240811de45b57c879dd
@@ -427,14 +442,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_amd64.deb
     digest: 60e1d9cbac4fafa4f7823e6495212ec02805997e64dead0f40de1d86ff138d41
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc-dev-bin_2.38-6deepin10_amd64.deb
-    digest: dfc649153e49fac79d623c0422c5853959c2a435775f0b049dd880460bb1ba8d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_amd64.deb
+    digest: 00d51bccb99085bb8b797d1da104893235789b72dc88f42f5d5d7b50d2139874
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6-dev_2.38-6deepin10_amd64.deb
-    digest: 24ec1c8c10e3ac6d4493c9245f37e65b5cd1edeca7eb606c6471009078312fe7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_amd64.deb
+    digest: 4a8025393fce99a77e4428caee83481ffe9bee64c2b985d0ac96c2ab2ab86893
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin10_amd64.deb
-    digest: 74af4581670b85d1114b7a875977a9986b890ae724fb5f80e60f0fc6156d4409
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_amd64.deb
+    digest: cdf2227d3d1614bb3c643012dddb2daa52abc647f90a820beb07f19b8ed6bdf3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcaca/libcaca0_0.99.beta20-4deepin0_amd64.deb
     digest: eef9bf124cff1a9617eb134d328b3862d6e1396783fbfe922b9cead4637fb9d5
@@ -499,17 +514,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_amd64.deb
     digest: c58e37fce60c661d023d37f46d1af34772c40783b2be220f0d11eb8e2d8029b4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_amd64.deb
-    digest: 57726c5fbe502348eda3a0ba248978a0769eb7fd134d8998386e3216875e18d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_amd64.deb
+    digest: 45ca2c611835e500875ddd500f2618ec97d6bfa51735ec3d276a72fb110e544e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_amd64.deb
-    digest: c3677b705c3b3214cec20cc24f7a4e4a05c975e1de8834e4647f5f2575b114e5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin1_amd64.deb
+    digest: e48aff0e7bd13a310516cfc5dcbdb68d789ef8e4c949afe7e638fb402a90f150
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_amd64.deb
-    digest: 94aabf445b3d15c635a2a1710066107e3f3860bcc15cdd982b3ae5581b132960
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_amd64.deb
+    digest: 14f6bb47e2fb92849593a1440cd87393d7920f5b7a0fa1932165c6bc8c96e890
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_amd64.deb
-    digest: 35286abdab600d5aede3a3e77030ad9f65535287d63be8140f0959fa9e0641f8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_amd64.deb
+    digest: 7e35233d2f74d5344630efc3bb2f91d2efb8ba7e62f01d5b095bb6bacc3c7010
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_amd64.deb
     digest: c8fd9506ce9de38317bc40295bd9c673d332e444771e00c6bf249373e424b82d
@@ -535,14 +550,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/libdconf1_0.40.0-2_amd64.deb
     digest: 80248ca6b6f089cbf601cf9f5fe5f65f875a291c8413e1c93067dea6ae746f79
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.22.1_amd64.deb
-    digest: b61786e652237c2b147355defd019aad4b68486aae5d33c0604dc0656a652b30
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.10.6_amd64.deb
+    digest: 1911929547c8e904871c7377a074fbbd146229621b284de5d57d8eb3bd7a1cff
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cdebconf/libdebconfclient0_0.271_amd64.deb
     digest: 19892f66e35d7f75d1a3d7a2ad53a67af9981a03a352777e07a1e8595bcbf509
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdecor-0/libdecor-0-0_0.1.1-2deepin0_amd64.deb
-    digest: f18e3ff04317d306f1f02e968393310456a7ca1cc4c1c5c18ebb462e78ee4d73
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdecor-0/libdecor-0-0_0.2.2-2_amd64.deb
+    digest: 7da1f884a5e8a8545347bc710eb180a0025272eeda1f5fbf0144d5811fb1cbfa
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-pdfium/libdeepin-pdfium_1.0.2+rb1_amd64.deb
     digest: ce7b5d8b92bb21bdfecba747cc071a7923ca5c31bb56d1934ded96d1ebb54ef9
@@ -556,41 +571,41 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_amd64.deb
     digest: cd72874d32e4388f985efeec06703b272bc1e09462172dfa52959a18520339cc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn-dev_1.3.8_amd64.deb
-    digest: 19b2307b324b749af00e94ee0d4118773e01126770a89d70dd2e4063cd2e1b0c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn-dev_1.3.4_amd64.deb
+    digest: 38cc6dda883d3361603ac7eed08feff0095a8683c256b85d3a92c34ebf70d697
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn_1.3.8_amd64.deb
-    digest: a8953ee0f6f806a65243194293f9cadf79852580d776c66583d39ff1efd91775
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn_1.3.4_amd64.deb
+    digest: f874df0806b19d01b67063614f9ebc8c37e44c438ab238cd3d1948801fe96c9e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.22.1_amd64.deb
-    digest: 7265e7b4460cae1426e0384f0b2b10b61bb29874d9d6629b9005cfc92ae1de9f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.10.6_amd64.deb
+    digest: ac3f1f4349e4d160e3dc29bc31e10dfc35262773b05180f7b0112443b8c6e36c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io-dev_1.3.8_amd64.deb
-    digest: 1c7e6bfeadc476d01c59f7a207887889031fc234908a546787cf20670dfb9e83
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io-dev_1.3.4_amd64.deb
+    digest: 015e8c7694b873fdfd348d79f65463cec1c895614cffb75e3c188f227c839f83
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io_1.3.8_amd64.deb
-    digest: 8d87a799197b9cc2f518f65207100913224d39909e64c8b63b5e1971411f03b9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io_1.3.4_amd64.deb
+    digest: 5b2f2833c01426b9f5e828e941adca1a20022e54504b387e134e363101d04379
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount-dev_1.3.8_amd64.deb
-    digest: aab16a5bb5fd67f12f1c15135a9334fc0731415c852d2e51fca8cfd94899b38e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount-dev_1.3.4_amd64.deb
+    digest: 33b4e58088fde72718b6a69a5e6db416b851e4a755118ce56c59fedd2bf73933
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount_1.3.8_amd64.deb
-    digest: 70ff5d931e0cdffb808b093fe2fe3aa0118d8f4c44ae10d69459d2d0a8f8860f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount_1.3.4_amd64.deb
+    digest: db7949793ccac7181a91bd4d610b26c80db7c8431474e8f4cf558d584a7c9155
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.8_amd64.deb
-    digest: 77ccffbfdd48541a12d51ad01d4b8dcec1bc3e9ee1bdb24b1a8d93b6a1b57921
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.4_amd64.deb
+    digest: 170be1a282e0b9d8498801d7919ed2495cf4241b5f0a578304d7cf060039e701
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.8_amd64.deb
-    digest: bfa83117dcac8df384fe712ed9b717b7019f885a33a902731efa438074b15f95
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.4_amd64.deb
+    digest: df5db86d0fe0a1ee209aec1568b7685e2e0e8b44fe845e9ab0c7f1a6c5fe95c4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.8_amd64.deb
-    digest: bbfbe5183c95c5ab8f33b57ed7179ec996ea459692af101a95eef6a28f878303
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.4_amd64.deb
+    digest: 51a48cf85be8f72645bd2c85c49a88a5ec62a85ba0069563a02493c2fac0603c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.0.11_amd64.deb
-    digest: 6071329202253a9351fe3741e46464aa7c522fbb8169b3762b15c4c16c146830
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.0.13-2_amd64.deb
+    digest: cb78ba057343ebd92bfd5ef643a6c2031115b750471d1173e9e6d6e43c757e7c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.12_amd64.deb
-    digest: 9b5bc46704f74411ec14c20ee7c6bd14cf8ac23d3fd380cb6d936711dab049c0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.10_amd64.deb
+    digest: daa6077790b86e2904b75316cc899228f41a26b09357f3979a598fb178f6d953
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
     digest: e6c6d028a74d0a752ae638ec19b8239f404c36d676c7569936f31000d25a75f4
@@ -613,17 +628,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_amd64.deb
     digest: c2f1676c3335ab76ff829190951052abef661b735f2ddfefdb8d6c0698c41756
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.29_amd64.deb
-    digest: 3fa1cdba3cd992ba9dd4a0e4c7eef18e19c92d6b7b016844bd19b5b338158512
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.25_amd64.deb
+    digest: 8ceffb3810d88965cf8f4b9cff067f53011112dd32a211495e0c37a9a8a948bc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.29_amd64.deb
-    digest: 9eb6c38d41bb49eb4559c9b4bface59c7529c40ec4dbf88276fcd6d1a2ac4328
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.25_amd64.deb
+    digest: 60ed25c9a9cb998a21b97cbd0451f4df0f5bd9f3872eef1d809575eaa6048c9f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.29_amd64.deb
-    digest: 10635e76101f748b9520bad09a4f4345418099fb96b50718ff1838dda8929570
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_amd64.deb
+    digest: 9a7716eaa20196761a0f87a86035bfb1bb2b0be1bf485b0697a70927f60a99cf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.29_amd64.deb
-    digest: 4496d0645447324e43b52ad59c5d861003fc412d0c62dbfb8f142b76bb206650
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.25_amd64.deb
+    digest: 2c91aaf3f276058f1c190d355ccdccbe699c6c1b5999edf9256fee34b5343d66
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.2_amd64.deb
     digest: 203f1e94dcaa537929ad7df2c33f9ae6f006985fc56829a37c67dce2c11660c8
@@ -631,29 +646,29 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.2_amd64.deb
     digest: 4af48ee588e9a27ca3663193177c4fd2b4e455cff00dbff0aa5fc2ec4bdd24d5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.29_amd64.deb
-    digest: 57520c034ab000063a2b2522aa841c91ff8199b6d319bcaa8a043264adf8a798
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_amd64.deb
+    digest: 34b0abc672d2c5af743d1a0836af2a258428422c3d1b87fb71507b0abc8073c5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.29_amd64.deb
-    digest: f04c47337c04d08ec2ae9c4a456092ba2af1e037f323303ff5af7a0c88fad355
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.25_amd64.deb
+    digest: 2d4d30307bcc41eb6cef9608603ee999aabf3a81d4ba2a7008e6bfbc232e0689
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.9_amd64.deb
-    digest: a66f430a256ea62ed8e5dcb29a2944c8b09c1bd5f2e1617f3ddd8ff97fe47f85
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_amd64.deb
+    digest: 880d256182fe9891a7874473fdd1f18439e5c1625160214adb9167fdba3159da
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcore/libdtkcore5_5.7.9_amd64.deb
-    digest: d3327e791e185d69a6b0d4cd3f61d3aa3deb459bc1df6eac151bd5e122186368
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcore/libdtkcore5_5.7.5_amd64.deb
+    digest: 48031c8e5c34e121f935be4484ba33f0d2709e7991cba9f5ccc822254de79fe7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.9_amd64.deb
-    digest: 8ab5c8a6e8ecc0f4b56ce4c76e2ace09ae49beeef613553227dd9c99fde9a0b5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.5_amd64.deb
+    digest: 75824b67ac4979f023f9a22ed326157e76f0c4d7739474145e4b51fdf55f83a0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkgui/libdtkgui5_5.7.9_amd64.deb
-    digest: 7d798e8b2fcce24116d6eb62fb63c99400af7473287302f422830a527fef1e75
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkgui/libdtkgui5_5.7.5_amd64.deb
+    digest: 1d9a6cdd48ec586c5bffbc6d59f9dbe614116d0ed4eed687ce5eb8bbd9193fbe
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtklog/libdtklog_0.0.2_amd64.deb
     digest: c09e76dc4e432430743105e05a2dbd0ff5fd70995ff531ebf28b5cb9293b261c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkwidget/libdtkwidget5_5.7.9_amd64.deb
-    digest: be71b8b5a05f3204e9c0a86db8ff227b0be96bb57bbe07bfe7dd2524c24e250a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkwidget/libdtkwidget5_5.7.5_amd64.deb
+    digest: 9ac99a10cfd4fc06154fa2839f863ba0a88c795a87ae6a3872f466b1c7744111
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdvdnav/libdvdnav4_6.1.1-1_amd64.deb
     digest: df4c7720a1876aa6b21c9f4909e031e005553fa0010f8aef6bc62090775ee2ff
@@ -691,8 +706,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libext2fs2_1.47.0-2deepin1_amd64.deb
     digest: 0b595c8ee57935a8ae1f2faa12ce8f3ad1a209cad39b12aba0db62144ad9862d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libfdisk1_2.40.4-3deepin3_amd64.deb
-    digest: a3332ca27930f4e9e8abd35922b0e4bd63460f2db1a744a766b85ecf21b9f85a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libfdisk1_2.40.4-3deepin4_amd64.deb
+    digest: 0fe3cbc2e8201361a14ba6814016b4f5e345d95d13ead80de2e2e370a25812a7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi-dev_3.4.6-1_amd64.deb
     digest: eadc61825e77bad028fd5eff398ac0e13da7a08870261058525d3f620d90cb7b
@@ -883,8 +898,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_amd64.deb
     digest: b4697179666eb012313127a7ff04d286f427b49523f50ada6d593694030c0b51
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-qt/libgsettings-qt1_0.2-4_amd64.deb
-    digest: 65731bf387458d83e5037c22ecfadc43b85511e7f76b83b3984de30ed7e9308d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-qt/libgsettings-qt1_1.0.0-2deepin1_amd64.deb
+    digest: 3346da2fee0a1e2ba5d2a06e576e6e8a6611e0c073b3c4137968d6a9d207f501
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgsm/libgsm1_1.0.18-2_amd64.deb
     digest: 7f037b2ffe20f167cdac62840fd0a333d15b9a13b58220db8094fdfb081d262d
@@ -1084,11 +1099,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_amd64.deb
     digest: 256423c8e3c4afcbdf72973db84b1e919187b65955c685ee16f9a5635d436943
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin3_amd64.deb
-    digest: eca7b2fc646578c828486698dd199588ab5a876b659140a2f2def5b2fe3287d5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_amd64.deb
+    digest: b88f61259a6d84105bed6041a41348d696d49ff8aea65ef1308e84d9399999fe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin3_amd64.deb
-    digest: eea2cca46f4eda0f1ca9e412fb0b03e4802df16b0ea20047ee2b4b142458576e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_amd64.deb
+    digest: 0034e277c6bcae0dec03e27a6b1ce99bac79a04e2157fd3a8448c5141bfd3fbc
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lame/libmp3lame0_3.100-6_amd64.deb
     digest: 79b03dd6b90ece528ed2103c0ad41785290e6ef4d80991179c15f11992031bcb
@@ -1246,14 +1261,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre3/libpcre3_8.39-13deepin0_amd64.deb
     digest: 66113fed5a1e26e6a762a8c1c1ddb8a6578dd59b6ccc146779345df9d8d87924
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10_amd64.deb
-    digest: 1cca8c85872210489e92326ca7fda2fcc8d9b37a085cd1a0c87d54aa685118e8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_amd64.deb
+    digest: 6338341b375c166ec39e466ef0282642c338d30d028a99414aac2b44a7efc3ce
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
     digest: b8f9b921c681e6c08abd8d452489762dc8ec3234e058407757f4f383ba2a01c5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin9_amd64.deb
-    digest: 50413f321fcadd29f6c0049d42717ffd6f32ad0531e306f3e4e9ecb6ffd4c3e1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin10_amd64.deb
+    digest: 1313e2522efb090a838672ded2d427bbd3853251a2ecef715c406e899ba3837b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pixman/libpixman-1-0_0.42.2-1_amd64.deb
     digest: 61dfa0134fe4038b88e3e64081f7340277297771d3a7c1667277cb9b992d2d0a
@@ -1276,11 +1291,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_amd64.deb
     digest: 300815c25c3d2b8aec8dfd4a03fe74da7d6bab832deb21fe5aa24a3a7e390885
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_amd64.deb
-    digest: 1b67ae47e78e8c2625ced4de739a0bd1362c4e4f3c874360c00646754699ee55
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin6_amd64.deb
+    digest: a56e4e77a50d3f726e2c0dcf9135b216167a632d8b05a41de91d7e68991ae3fc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_amd64.deb
-    digest: c4bb92580ee19b51ab4dbd0f08b0edc1b968a32e718ae3d9615bffa9610ae6d0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin6_amd64.deb
+    digest: 6ca8a10b5549cd052c411d9ff4ad6072a3017644992e6e70565327339242dfa1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt5-1-1_0.200.0-4deepin1_amd64.deb
     digest: fed9ba8ebaed171f9aeb4ecc52064c365c6fe158caf0f4bb61c4118d5c328d71
@@ -1309,8 +1324,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pugixml/libpugixml1v5_1.12.1-1_amd64.deb
     digest: d2c6567cdfc03a1b374e06ae654501014912a24b098c910b713b5653301bbcfa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse0_16.1+dfsg1-5.1deepin1_amd64.deb
-    digest: ad40b445b798ba098f7191b90a5e949f091b039bcb5961d271fc9715f3f2053d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse0_17.0+dfsg1-2deepin1_amd64.deb
+    digest: ae0d0ea5f41475d7382d2192eb99b606257b857a44e9d4287302c4ac39732052
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_amd64.deb
     digest: 7611dfe764b5a109e1fa516270c304d451aa2980190c480a83b90207a6b84158
@@ -1369,14 +1384,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5xml5_5.15.8-1+deepin9+rb1_amd64.deb
     digest: 5b309e4171e413c1788b4f3743227d2978c89ce0eef22cccf56c4455c7780a09
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: b86e6ae350e134bca5ac669a2876471443912a4d97837f48f60899e410da30e3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 2b27dda887d891e316750fb1b7bd56fafb097c1bcb0f03e7ae0062561da40a6f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: b6009748b31f56da764fc15883158f5f7698e8adf1b4a26130be0e39c969a1f0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: ebd40ac7c53cd6b669568467e3b9b010abbc030ea1201662a74e0cb95a49698c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 9a89c7bf053a7b61f424fc07fa642aa99de4e405d03828796deaf89cfa185d82
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 54dc26fe98838334213678668a1cfd3c020f2f050ed8378c0b8924ec1af8cc31
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
     digest: a6864707b38a192dc89ad51546e958fc2095ca3b45e6ee99e190d48ef54793ea
@@ -1384,23 +1399,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
     digest: 033f970ed9f2486fa265bf3a10332fc18fec0b9d0a83d74ba999007c4d647fc9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 82661a44df0d42729d0c2147db74282e4200e44816e14c90e809fb5e357884fd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 41dd12c029ef2a97fc9524b773c007642948bb0968f71f6dd08538dd03f8d375
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
     digest: 18db346cbe4e81620934c3b232222482f5c1251725516d3fb620c10ef2bb2611
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 0d3a4f43f1cbb6313f681f2e2fd74a6f2caaa5bb563f01dd118313e46342733c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: d8d2854d73ebeb2607bc90ba83cfa55b67cee62ac055bb1b6228bd426fea4363
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: b4de6dbd0643ea38f055fa28d6f16464ce5af49c2a6614fcaaeba628aa2d6641
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 7e1f0b187c5e82d45c06a8b3849fcb4e2a6cb6a31b950f7622ead3747009c54f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 1f513949af168b742864d3a3c16bb6bc4860151e3f062d8728ac0b318e89e6a6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: f87c83461bc1806acf203a7e52a8c47e32aa5e42ede0d26f0ecf8a26bc914576
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 5cd4c41868576f0d5aae5bc10e65f72e26686ea47bd623c70048ede7e6b40456
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 4c1a62bbfb23764fbfc250027bab219087940ba16fa680b1e7348dcf418906f4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 4f9d66873e7e085fb6909fd47be1fd50a41a8dd4b15b38bc77ab2dff42e43cf8
@@ -1420,11 +1435,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 21cd8eda13f476ec71438f56f43ed8933cc0b625302fff4c6f23baacbfb3b5b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 808397fe4fb393db11c7c4bdfa2658914224860ee36e0be38573ecf9d2a9ebbc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 528e27bb9f946d602265cd8a43853f56b2754f3c945ac7bd64a099d7cc589f34
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 3499d8d1f082a2c75d302476c9f4db605ada73a12b2a9bdcb53fb51ffa6af212
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 105370dae395895df950cca059ee1d11aa5f6677a554c7331a83bc0da959ba52
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_amd64.deb
     digest: 0e43640fc49faf57d8454012338aac69b638356417a4a2361f3c0e47271ffbf1
@@ -1432,20 +1447,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_amd64.deb
     digest: ba29752fae4494fe62f5a4d3f139386078d8beb74e53eee1d7c673028a8adb97
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 8d0de49dbf274d0298444cb515b64b52b15d3bc50bafdb312330d249197e40e0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: ae45f73efa9232cbb98621c9ecc12488a7ebf687eaf9866c2e171aa37efd96c1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
     digest: 5a2a509181e35a92f6effe0f2ef107c7dfadccefde35548bb1ae568aea003fb3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin4_amd64.deb
-    digest: 88d55f6992afd8662d7050d82d0f23db38f74907b8f21e2d4ab8a5ca51d4eefb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_amd64.deb
+    digest: 70486bbc5555f857aff3ca539dea86df4f800d20ad4e20b3cc5b62b9a6d75b21
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 06309dad2d0216c11d448a767df07214bb01e20de87cd4ecebaad52514c2e10c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 4ba7721998329f33d49cc6f82add0a1a6819b59c4c8ba1e82dd084bfa3235ca6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 76bca389d0aa0a0219ac42a0fbd5e483a33e2d9c38acd226eb2fc46d76e606ce
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: d311d6a7a8cf93949f715bbbb271149e3396966a60611a086b05b125dd17c77d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
     digest: 4b74d4425bcb1d23d7763e62cb1c9f2be712d9f92e46542151125ba96d623164
@@ -1495,11 +1510,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsecret/libsecret-common_0.21.4-1_all.deb
     digest: 2c12c067604e4872a281ddd17347c2a8bfa35ec65c086d46aed37414786205ab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_amd64.deb
-    digest: ccc4c248f64dbef5e3b9711491fc93a903e4fa15d1616f5ee1bfa0a5cd82c73b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_amd64.deb
+    digest: f7dfdd9e463828cff8e624ceda7f13cc68f2c9d2e72b27dc7e7315e1193b7d92
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1_3.5-1deepin2_amd64.deb
-    digest: 6702f261991679f2b5fb4643acf010396a12d3994e26dd568628f433e6f0f129
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_amd64.deb
+    digest: b402ade709a2820f2562dfae7acabdb41e59916ef931e5b9d270812cf2b7fc20
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsemanage/libsemanage-common_3.5-1deepin1_all.deb
     digest: c4fe4277d3df3d1bbf39083659701e5f4f9857e612ef7f1185e45eedc8f27047
@@ -1546,8 +1561,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsm/libsm6_1.2.3-1_amd64.deb
     digest: d8a6d0abf65a6fe4c5edcb5fa37b115477736e60c31118df74b701a468b49cab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libsmartcols1_2.40.4-3deepin3_amd64.deb
-    digest: 65af1a5dc48bd6c44ced7026bd077e20fdf7c1e9d2730eedc9d1484400e3c575
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libsmartcols1_2.40.4-3deepin4_amd64.deb
+    digest: 5e1fef152a69db81f2be2a1afce464acfe6ebd4cfe1671d0327057490245453e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/samba/libsmbclient_4.19.5+dfsg-1deepin1_amd64.deb
     digest: 55d7bfe47f43b40e3d89e24d8432affd81b9186be88196b3ff5dbe5e05278019
@@ -1582,8 +1597,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_amd64.deb
     digest: 9736df9018121b8368b482278a533284a82da09650baa3cb3541fa58cfbc09cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin9_amd64.deb
-    digest: 162919c6f9ceb11c176e69d31bf431f9fc95cfe6d3706c3b0ea93f1d768cf9fa
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin10_amd64.deb
+    digest: b59b38d5fc0284fb0082a4bebbdaea0bd36ef0ae00d520a02ce2ee0b442b7dd1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
     digest: 44381cd9ad35fa6ffa7a0b3e27611011602bb32093efaf0c80117dc9f97a371b
@@ -1693,42 +1708,6 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
     digest: d7c7fffd808cd0b765d2287b98bea752d740994788dbf90de6db4f9710e41162
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-mu0_4.0.1-3deepin1_amd64.deb
-    digest: 62097196d9a0a4733b3a56d3a36625e2d536b6292e18cc7d6a4302ee37de451e
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-rc0_4.0.1-3deepin1_amd64.deb
-    digest: f7d48530becabb1ed24102bcb2a3b0e460b68be3bbabba86c24a39ff7ae807a0
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-sys1_4.0.1-3deepin1_amd64.deb
-    digest: ce47f4a14d736cb5822466b4048f2d42d13e53372904af02fb8bc9a27b0ed5e9
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-cmd0_4.0.1-3deepin1_amd64.deb
-    digest: 74e05df8cf9bba8f0e3bbc4acc597b1d0ccf1a9cd65579ba64373406d68554c3
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-device0_4.0.1-3deepin1_amd64.deb
-    digest: 203fdab84f2e07c30669e2c1bd4f146a2b75886f1268af6f8f34de8b610a0ee7
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-libtpms0_4.0.1-3deepin1_amd64.deb
-    digest: 5e433c4faa2a1a3ce1d88e57b8a8e2c5fd6c9a9352c7d250d21e56972804211b
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-mssim0_4.0.1-3deepin1_amd64.deb
-    digest: 77f2f78d83d44f859f5429918fb8bbc707cb85d10c020d0fd57703b99ad79ea5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-pcap0_4.0.1-3deepin1_amd64.deb
-    digest: 2d0efc10976da863e747b191195a85a0b30f38aa2bc022196adf44703354a46f
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-spi-helper0_4.0.1-3deepin1_amd64.deb
-    digest: d7a356c0d648be79162dcc3f4aa293c45a851d94a694ee8d87aea4d1d9cf5815
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-swtpm0_4.0.1-3deepin1_amd64.deb
-    digest: 9c363b7c37a1b8686dcc1a11a9c1b804f64075fe05452570767ef680f160172e
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/libtss2-tcti-tabrmd0_3.0.0-1.1_amd64.deb
-    digest: 1f7bee17462aadafb7c037717603e773c43d8f7a929e672f47488676af2eeff7
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tctildr0_4.0.1-3deepin1_amd64.deb
-    digest: 3c61f3878d02985a3b5a54bfb8e885a76ae67128bca04eb43e8a9219966da3c7
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/twolame/libtwolame0_0.4.0-2_amd64.deb
     digest: fdc576e8da6c75367f25d569902e6217db30f61d7865f35d43a53d824856c974
   - kind: file
@@ -1741,11 +1720,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
     digest: 5ebb4a61642a553212842e52f9bcca0bcdf2fa47f95d8d1a4b30d6096dbda8e9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin5_amd64.deb
-    digest: 86fbd826ec1026f1c7c5a9a5bc73236ef798337c296b65f2774702c683500729
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin7_amd64.deb
+    digest: fd0f890c9f9a512bbc9da328f1ed93e7f2803ed0fe0ddd96a740e471bf28c7cb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin5_amd64.deb
-    digest: 509ac152966bf5a53d75f0db14d35f1b866aeb244d25a43397f0155f0643748a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin7_amd64.deb
+    digest: 6fdb045767176891bf241efa4a33f9daa7533b80fa5c875a9af48680b8dd3b0f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2-qt5/libudisks2-qt5-0_5.0.6-1deepin_amd64.deb
     digest: f6c839cdfb569b151204221be451c5959770b80f42f1e2c497baa250710a34da
@@ -1762,8 +1741,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libusbmuxd/libusbmuxd6_2.0.2-3_amd64.deb
     digest: e7423084acad5b6ab2106b790e7548f6fde6f48ef3f4a9f0bf53a8db3358d8fa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin3_amd64.deb
-    digest: 82dafef8e06fdf4a38c40157cf0aaf45a102949cec7e076a9dedda6b3a14a692
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_amd64.deb
+    digest: 5ff4edf566b7bbb9d4e6c175a5d58c26aaaf201472f12433f1de46f546945d03
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libv/libva/libva-drm2_2.20.0-2_amd64.deb
     digest: 3c519c4dafb6a654f92945151f133ecc09263a62a030ceef6c5357e0dd3dc731
@@ -1843,8 +1822,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebpmux3_1.3.2-0.2_amd64.deb
     digest: 4732ad39b0b2d4504983466503fa0ea1ba286c42aca07feeca8055d91e17aede
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/webrtc-audio-processing/libwebrtc-audio-processing1_0.3-deepin1_amd64.deb
-    digest: 8cda96bfd71a79594b03f94ee729891a2052fcbc40f58987bcd1762dcb68281f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/webrtc-audio-processing/libwebrtc-audio-processing-1-3_1.3-3_amd64.deb
+    digest: f10aed6a614ed98e24103f6ba7c41ce0bffc8d07a0e17370ce5e557f180e4dba
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tcp-wrappers/libwrap0_7.6.q-31_amd64.deb
     digest: 40b9546740607b7907a735481fbb471ff771c5d1fb2ffa7aff4c7785b8e4899b
@@ -2029,8 +2008,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
     digest: 68fe4a526d73dd2ff6b75c593a5a4059486d1ec2535ec5e42cc52057a52744d2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.18_amd64.deb
-    digest: 8d361e94f1d128462cd7992e1cbd7eba4571762391dee7016dce8ca2766761eb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.23_amd64.deb
+    digest: 910b0e2a76285993e3286050592628ec4c7286a4e7d39e438c3f89019db69a30
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shadow/login.defs_4.16.0-7deepin1_all.deb
     digest: abed558f44fdd893df5020fdd787b2ee1b5cbc8b5e4b78ab4b01b8f1cc1aad08
@@ -2056,8 +2035,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/mount_2.40.4-3deepin3_amd64.deb
-    digest: 3d2921e60365914a8b4907e155d6073e53c4badfbee8e2b96c2347967b264d17
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/mount_2.40.4-3deepin4_amd64.deb
+    digest: 03982d0b90de3d0fb143d4e0720959c8181959e4f146b529b0683861f4859c7e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
@@ -2074,14 +2053,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/patch/patch_2.7.6-7_amd64.deb
     digest: 4bf340095bbde164d3ca33360e3b9d89a2f92bb1912cf2b4fb21a266c2ca250c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-base_5.36.0-10_amd64.deb
-    digest: 50fa4a0bbefde86abf9ffd1fa092ee82af23ccc8f65b5b952526dc885c943169
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-base_5.36.0-10deepin1_amd64.deb
+    digest: 7b56a354906c81ebfb301c74af9558ec15da38f82963b9002b157d788c1e55f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
-    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
+    digest: b79ccae8397e919ee917cd187b8be2d3b10eb598f43cf72a9d9a50c3d81ec288
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl_5.36.0-10_amd64.deb
-    digest: 59d13b610350339f3b273097011a3db6db60a99d587bf04eeb881c1a34168390
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl_5.36.0-10deepin1_amd64.deb
+    digest: 1f28deb9739ccd0b2569990ea9fe58bdb5c363c8bd2b60a1dd8721da9d33f655
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pinentry/pinentry-curses_1.2.0-2_amd64.deb
     digest: 592dda797941374415900d91547e276459146fd248fa2b746a8e69787af0dd8c
@@ -2116,11 +2095,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
     digest: 1ddd2f46a8e6b858e589bb011fcafb498ea673c78dd248283284b8a188cf996d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 2a1c39207f4d540c353ed19697ced883fcae42580f8e430979e6d33bc9a70ffa
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 2bd4061502b590e7e78fd5cfe089eb7e7fb173a15fed2ced98b50737549b8208
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 3fcd084de54c87a8e585a6ad63f705d87b3305f97cee48e13572d16ef5fd9090
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 17025348f2c9c6a1dd0742d8559771261dd4d297c9e3fc856ae8ba91a0ddb6bd
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 359f5fd7d83789deee753300437ea35ef2004a4ac03c5367249246addcafc210
@@ -2140,11 +2119,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtimageformats-opensource-src/qt5-image-formats-plugins_5.15.8-1+dde_amd64.deb
     digest: 3c630e56673d5358209521ca18e2bca38f50f9c7372adc839e4150a947ec55c7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 60a17d82e7c5d98d78a845d45a028596d6c1deafc697a2d98c84d01917d3520b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 216615817367297df6cf55a42109f53ecedebdf973ad3ee5aca0a8335774c65a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: efc3e179458722b1133810cdf62abd635ebaecf2a846e099f083fc2c970b5688
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 655b85be8e6045818776113a226aa32bd3b5aee2edd6db07ad86ea65e565b490
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
     digest: b9e766a60ff54dc40cdd1307aead4f3c2c1997388e21fe36ec37650bcf650384
@@ -2155,8 +2134,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
     digest: 9ebce5aacbc3bd447f6fa109d03647369ec93d054f45a4b6f332b2643ebf9c0e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin6_amd64.deb
-    digest: 587cc4d95fd86318c9cc381091e834c0201d7c931145034db958014bae20faf5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_amd64.deb
+    digest: 5264d118de60afa8f15122126da05a7663ed8cfe0b592bd9de18bf290f26d92b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_amd64.deb
     digest: 0acef551ad9074060268eabb8d0b2b4703b005b00672a23406346e19d7346de7
@@ -2191,9 +2170,6 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-dev_255.2-4deepin6_all.deb
     digest: 41bec4491af5737e55f1c186ec8bd05d24611dfaeda7132354e75ccb6ea7dd68
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-standalone-sysusers_255.2-4deepin6_amd64.deb
-    digest: d7b4798f994c6b3facce63557fa19db15033f826dd0f33f33a56ff18dd00e904
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-sysv_255.2-4deepin6_amd64.deb
     digest: f4bd7b9c80e3a8a3312f32eca43c894823867f536e8e27b2ee3751ba2290d829
   - kind: file
@@ -2202,12 +2178,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb
     digest: ee27ac0010bb1525067edda7b6b86110a00550232fb154f87491dbc3a3a2c8ff
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm-udev/tpm-udev_0.5_all.deb
-    digest: 8305c01b236dc4838bfd5f3331c403ed344207b35808d4bbb76dd58471a65b60
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/tpm2-abrmd_3.0.0-1.1_amd64.deb
-    digest: f221169b672818cd0fa0ff81e358f706b0b2fe8c8c36bbf37e8bf45754954b1e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
@@ -2218,17 +2188,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/udev_255.2-4deepin6_amd64.deb
     digest: d9fac4347299aef24fca8696308c103ed2efd3b387af4384ad3841fd210984d2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin5_amd64.deb
-    digest: c1558b1c7c64ec494259ab2f8f04037173e43444002c38210d0288b65bad041e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin7_amd64.deb
+    digest: 23af2e5ba810974cd5a0e2f707998427e0a6d1caf4f1eccd2164b63cc790d3e8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usr-is-merged_38_all.deb
-    digest: a955d8f015290e7447210d049a362e3f04afcb82fcf1f0b4403d13df7b4f5fd6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usr-is-merged_39+nmu2deepin1_all.deb
+    digest: e8896ae20e16a3b4ab0ab4caaadf884de1c0056ff449f85ff1426415e8758a3c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usrmerge_38_all.deb
-    digest: fdc636985788b18a04cd15941a111fb2a73d3b56cf58c689b918345e6f003161
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin3_amd64.deb
-    digest: ccca10cdc656ba81fe22e263128d472d50ca024a14ad2e061a426d672f941ecf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_amd64.deb
+    digest: 15c9b33ab745cce30a6d51d8af8f0d3ab80e68af8dd21a416e16e60c2af359fe
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
     digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.19.1
+  version: 6.5.20.1
   kind: app
   description: |
     font manager for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -79,11 +79,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/bzip2_1.0.8-deepin1_loong64.deb
     digest: 08d9f48f571bc206fe4e30a27e535a3a086b9dedba4a5f5055e898ff0dbea7a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-2_loong64.deb
-    digest: 7d38eb3f86f982f681a61312c4cb4892cae4097c5cd50e54004928888b61708c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-3.1_loong64.deb
+    digest: 41c50dad5e3b6af472e6b802112255405b7274fb33294f4ef30dcb150309e04d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1deepin1_loong64.deb
-    digest: ef374d0c418a14fbfc03dc28859c078a81aab09cdf6053857b3bc7d05f667656
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1+rb1_loong64.deb
+    digest: 6bface8bc94c5da84250e58d56df4bd774a6e3eb7360edd6155416cd44938ffc
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2_loong64.deb
     digest: 54c83cff0f70b77841454545cd9fe439c36284971788ca26115bcbf420cc9649
@@ -121,14 +121,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_0.0.1.16_loong64.deb
     digest: 19fb0bdf1c042bac06516442352a4191c0159369a8df8ee6eb23950de7bc0efa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.22.1_loong64.deb
-    digest: 190c8c174e081f0e722007ce8ee142e1f8ef2d27664d243894015f5ce3d884fa
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-common-plugins_6.5.10.6_loong64.deb
+    digest: 0f8d2e9e4fd805ddb1133b2b4404981944da35cb2ca7244c00e3fe9f88431f8e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.22.1_loong64.deb
-    digest: 6c7f805a32d9f495da7f5cdd27cc0beea4f22410489db8ce2d3dff7eb1d7276f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-daemon-plugins_6.5.10.6_loong64.deb
+    digest: ca8c409cd5f11cd7f2e34bae5a9e82ca394f46c62f5533092ac0e9e04260b0a4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.22.1_loong64.deb
-    digest: 6d997638e6915d7ac5327aa34fa4f8fab43725c11d14894365cd5d6c6d5c0ae4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.10.6_loong64.deb
+    digest: 22aa951af206dea76163afe9ede3a5afe9fe9a88f9dabc16030958d8871b642c
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-plugins_6.5.10.6_loong64.deb
+    digest: de5a66d83c03fb6d424506f5884951f71a09766765581a7b52f735a68cef668b
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-preview_6.5.10.6_loong64.deb
+    digest: 558d0c498d41aba9ffe14ec9ad5106e97b1442d7951057b9395ea07702549457
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.10.6_loong64.deb
+    digest: 45216e9e4b20057e2d0d167ff5e5e8f44c680cce460ca82b09061d42333601d5
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.10.6_loong64.deb
+    digest: 35937cda78602907b6b19affc84c16dad1c5fde89d56ba35bd0ffcac044de36b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
@@ -142,8 +154,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/desktop-file-utils/desktop-file-utils_0.26-deepin_loong64.deb
     digest: 1ab06af75ac5357fe59742b9411f909c2be9b112027a9b2c46f7bad36023d4c2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/dirmngr_2.2.43-8_loong64.deb
-    digest: b4482a90a83e8cd8c952558f19beab8c40ec3245c1635a729e98ce0ac062830a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/dirmngr_2.4.5-2_loong64.deb
+    digest: be2d0223f00e328a62efa01dc7b1b41b5a2b1ac0426db283fc04fa1f4d41f963
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/dmsetup_1.02.201-1_loong64.deb
     digest: cabbd8c3547b8dada85be41e44719526d8dc478f35a50d58b26b03ee293d62e0
@@ -202,8 +214,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_loong64.deb
     digest: 5770bc5dcc6da72cad3770a54023a87e2e1af8f5fc179def0a33ab3d0a79866b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin5_loong64.deb
-    digest: 2bcdafdfe33baebb0a6f12aeb8bf7a2b43fc3640d5ea344493417e2c3b2f99cf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin7_loong64.deb
+    digest: d8994f29763656aa045bd17b9d84b5e152b497b13d934ff6c7bbd9e1b809fc6b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-common_2.78.0-1_all.deb
     digest: 94bfaef9228159f8a2f366b9962e5bd82c9ddb53228b161d62c6f5d48ecf1c3c
@@ -214,26 +226,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking_2.78.0-1_loong64.deb
     digest: 388e3237a15d2e4b1e7a685f569dcbc4583f0f271650262ecae55508308ee0f6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg-l10n_2.2.43-8_all.deb
-    digest: 9c7d9c4452b94dede463c7f748a0dca699bc03a94a5167ba6856c2f10b49bb8e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg-l10n_2.4.5-2_all.deb
+    digest: c9e04d548f5db44bf2772cac43a1fae57f0711e9ab939d0b8eaefa284f50df0f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg_2.2.43-8_all.deb
-    digest: a8ddd90a1334b1814cca606ce19911bbd222a49b1b99ee3c58ca91d819251a20
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg_2.4.5-2_all.deb
+    digest: eaa96043881596b22aef5933bdc2f096163e24f0e12a8cdb4825f6ba8ab6e96f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/googletest_1.12.1-0.2_all.deb
     digest: 2df57ce8c5c8fdc37e1dbbe302d276f1cb9a784df5dd3423208f87933cfa28a0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg-agent_2.2.43-8_loong64.deb
-    digest: a21457d6d9a9567a44b6fdca7fcc47d956a905b609c6776a0bf777d1c38c5bde
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg-agent_2.4.5-2_loong64.deb
+    digest: 39aeddec5d3ae9b23d0e79c9cb00c489f0d804b50558de313127bca382e4c75b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg_2.2.43-8_loong64.deb
-    digest: 4ce04be74b76bd1d85c9b16bc2ee351b7e5a4972d341ad8b0abfe6e86843c071
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpg_2.4.5-2_loong64.deb
+    digest: 52a2f2ba068b168440f1ab5b1f17ad9528cb36649df58b1f30d683611767e46a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgconf_2.2.43-8_loong64.deb
-    digest: 8814f461714ee2398e547734d5d5bd5ea70d910b7eea08ad0fbfc866799972c3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgconf_2.4.5-2_loong64.deb
+    digest: 261b45475223596236fd2b2dd18c643d4b8f71c61becec150ff221974b0e18c0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgsm_2.2.43-8_loong64.deb
-    digest: 1a2cb0ca9bbe57b16a7fc2b325bebdb5f5d7b58ef376077adb48dceaca91c094
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gpgsm_2.4.5-2_loong64.deb
+    digest: 554c4752be20c4977adbd9c1ac3f1153a928209db69a23b5ae54d7b35a78374b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-desktop-schemas/gsettings-desktop-schemas_47.1-1_all.deb
     digest: f87ebb3a3d4d6557f779dd83909a6aa79282e7085aacf756fcc828bae36526eb
@@ -253,11 +265,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gvfs/gvfs_1.54.2-2deepin1_loong64.deb
     digest: e8bc05b296223762a5eb962f517d27b6248d067799d19ef482a10fa90aceb8b5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/hello/hello_2.10-2_loong64.deb
-    digest: c1392f82149a302cc2f202142ad5404e7a227d9c43267c8f7a4518620993bf32
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
     digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/keyboxd_2.4.5-2_loong64.deb
+    digest: 47b83fc0454babf0e369e111d3010ff3de0fd00d388c375b641af788a6f39b3d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-1_loong64.deb
     digest: 6a5d883c7ca1fb96e88290e5f80f2310b83e190d02133676ef19fcce44b5fc39
@@ -304,11 +316,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libbinutils_2.41-6deepin7_loong64.deb
     digest: 0072ce1b04c7bc89f5a4a9e0bc9345ea6b7bec1c7469e2ddf3ef5ae1ca955853
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin3_loong64.deb
-    digest: 07d80c805f026d7b2247adb075410a5ab75a92f6d3dd4efd353359d98b43c953
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid-dev_2.40.4-3deepin4_loong64.deb
+    digest: b8c86c20ac3f591b298fafc9d94b91f81df48f1b59a65493933e79dce235ce07
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid1_2.40.4-3deepin3_loong64.deb
-    digest: 4254dce7ca5ac435625c94f27a9dc3d2fa5e4f56b946e4593b752a540c4da59f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libblkid1_2.40.4-3deepin4_loong64.deb
+    digest: 9997f65a9ee404fcfab2ffb048a597d3b44bfd985495375b9b35a4b0b4c8dad2
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto2_2.26-1deepin_loong64.deb
     digest: 000fbf384164b48eeeb7a0f70dd512fd2bd473cfdcffedd841a3038f60b9e0f1
@@ -400,14 +412,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/libbz2-dev_1.0.8-deepin1_loong64.deb
     digest: b073876e60d9f9ba41ff9f984d0895c37684272da7ea5389b2ceb85598e3154a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc-dev-bin_2.38-6deepin10_loong64.deb
-    digest: 31236fa3b39b50dedd99a25ffb8aca033ee3a7151991bb6d3ad32098a40aea15
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc-dev-bin_2.38-6deepin13+rb1_loong64.deb
+    digest: 9fa3bcc93dab003763d83db50c25081e29ded90e14d44fe404f6d5b052f1e006
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6-dev_2.38-6deepin10_loong64.deb
-    digest: c51838ac3f5d7fedc93febcabda1423ad26189a2e5a4381b4e0ebffb1be3b3c1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6-dev_2.38-6deepin13+rb1_loong64.deb
+    digest: b50b71c9c338a8b778c53d3263b155a04f5abae803827cad1f698b015826d2b6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin10_loong64.deb
-    digest: 950b7cdc8e0176888434eae1bd940a8739e54e42f363f33f973cac4b2c63eef1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_loong64.deb
+    digest: 4d25699d2b3054ff228cf4e83822adecfdbfebb848f2a9bd0786704ff915b6a1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap-ng/libcap-ng0_0.8.4-2deepin1_loong64.deb
     digest: 8273873be5fb356e98e3200f0666ebc6a4568e46f6457f0e14acbf9d844d1a82
@@ -454,17 +466,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_loong64.deb
     digest: a594bca37501a18b322a46118883ed18bd99ef7d31eb5e5220a2d7c1adc4935d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_loong64.deb
-    digest: 7452bfb8da2bf510f5095db334f7730c914a087571d313172392b1a2b12b986e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_loong64.deb
+    digest: a6bcb173e61ad5273becf725933fff6bb10cfbe068d4a9a23af53b542b47cb78
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_loong64.deb
-    digest: 2215b8b403b997e7ce667895f92cafeb22ceafcec9dd468c6583aa2dbe83393c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin1_loong64.deb
+    digest: f81c3066868743ee4c5cbf09088c1b7f8dfc38832b358012ebbeab92a1428051
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_loong64.deb
-    digest: 07c0d38b655ad9e1dc4d93ca4a858255adb25dc7b131ae1509781b83f1d2d133
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_loong64.deb
+    digest: 51248257d36d6528d3cf0cd7f038c6da2cf929267029b18a13ecdde2213cfb25
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_loong64.deb
-    digest: 054a65c1507942291091fe19cbb3ca046ab48e734b4e8a2a77939fa427a89363
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_loong64.deb
+    digest: 3c9ca124f4de35b207d02b042d1d25bacff0d4a642e0c34ace340d4667e7c037
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_loong64.deb
     digest: 1e92b0e84256009fa0d4afa40bc765076fb97a45ab25e4f27b29a18a8b3445d6
@@ -481,8 +493,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/libdconf1_0.40.0-2_loong64.deb
     digest: cc045f5e127c57d0e051177ce11347f3c46f20c345786f2082f6cf11ec00ff31
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.22.1_loong64.deb
-    digest: eedcbe8ce4a3f1ec716204c76ecbcbfa70c1dd543638b12c6d5442187d05aab1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.10.6_loong64.deb
+    digest: 8b7c1a6747194d740813699b2b0782300a5b2e80b799e219d4ee82a27e730385
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cdebconf/libdebconfclient0_0.271_loong64.deb
     digest: 13dbf4cdea963eabe585bb8bbe3f16489cd990adb00cfcd870fcdfcba960a967
@@ -499,38 +511,38 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_loong64.deb
     digest: f52242c7bc863bdf87fda9ef7accf1e12816999fb5dbfb590325399eace9052d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn-dev_1.3.8_loong64.deb
-    digest: 3978abd77f052b57ace1327ffa7436eec1872da4f321f5eb21042c5b018fee50
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn-dev_1.3.4_loong64.deb
+    digest: 87f958d8e1275df925f92a67367628362bd4bb1073dd8bd7dab29057cadd99e0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn_1.3.8_loong64.deb
-    digest: 36cfda3d4b23ae871d7005217b61806b3bc236ddef185b8b8bab0dafa82441b7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn_1.3.4_loong64.deb
+    digest: 2d2bc896913621876755eab309730627bf7f992f42711e0ffde2cc34ca664683
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.22.1_loong64.deb
-    digest: d7705432e4dacae17bd2b5cf1323832b82fa5a9b1d6cfeb05361becc95c887d6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.10.6_loong64.deb
+    digest: 9c70a3d28a2cf1f7f95c9537982bbd4d0cc5dadc1b670836c947129f40449216
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io-dev_1.3.8_loong64.deb
-    digest: e4fc319fe649dbbf8634ba97c30d84b552abeb63df11b9be1c56450dc4e8956a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io-dev_1.3.4_loong64.deb
+    digest: b6eef432a664c8e34ce81bd19936990c94e8843e790e486852d615037f72712c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io_1.3.8_loong64.deb
-    digest: a6bba4277a35885a20a1929dbf7278777f984ee49256ec171ae16bfe45f24d84
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io_1.3.4_loong64.deb
+    digest: 05cba15aea4f5916dc671442b917413e0cd032c5c9b163c026acce08db43ab6a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount-dev_1.3.8_loong64.deb
-    digest: ec3d872e19a63deb4549155b2ec1a0f02d7a9f189f512e9fdd9fcc623817074a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount-dev_1.3.4_loong64.deb
+    digest: 0072251c611774a48852e0de97c2ebfc9323fbefbc18d6a26e9b2c6611aa3610
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount_1.3.8_loong64.deb
-    digest: 552723f8808cb1e33ca3a809f9aebaaa89edfa2ee40f506de53cec9e411dd90c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount_1.3.4_loong64.deb
+    digest: f21d91e9b1d2c1ac953b44bd9618fd3a5d2ce0e733d1b3c02c03f82b5a625b3f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.8_loong64.deb
-    digest: d218dfd938969fdfc3bf744c4b9b8d793288378831c0305aa6a42a5693fca45e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.4_loong64.deb
+    digest: a547fd8fecdfd82971d870835dec038153644a49779fbec07cdff9906527e71f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.8_loong64.deb
-    digest: 2d8b56edb1e736b991d6b411769855b9fbab4225ba3c728b754d8c2066d8ae6f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.4_loong64.deb
+    digest: 1176661391a4d283085cf917cc316dd1faf123448ac8546e5d105377db44f5f6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.8_loong64.deb
-    digest: 1162f51bc5c429b32dd66482197bba4a19c37d77ad5853916732db7f309671cc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.4_loong64.deb
+    digest: d4a198bc1f6fd6a26fe45a3ec3df9ede921e1b23a9812f9ae9ac5c8dacec8d23
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.12_loong64.deb
-    digest: 2d89c09796eb35a533597e578dc396281be252be610ada6f4dce6e981d9da45f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.10_loong64.deb
+    digest: f2beb1da0ae184a67feb67b7e86a49d48d453469a044bc12f27320aa35e71975
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
     digest: 1cb1deef108f4163f884f564e9fcfd429adc315e9509c30ff3bcf936824ac543
@@ -550,17 +562,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_loong64.deb
     digest: 9b28e3fcb6cff61e26352d3b426fe25b0c19961120d499fd5cb05f5177b411bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.29_loong64.deb
-    digest: 5aba8e1d0b9861b15cb454d2efdcafbf6a04c41e030839f3e15ae45c9d59009f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.25_loong64.deb
+    digest: 6c61509dbfa71c1bef66b405f76a18e4f68e62aed4d55626fb2fd2e2ac87c8cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.29_loong64.deb
-    digest: d762d576576b6c7fe621eb5c5b1a71350103e6ca5854683266183c65fb6976e3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.25_loong64.deb
+    digest: d637527e884ee0fdcf6683013c932de3230c7c357afc87a4d2e31e0250c76d84
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.29_loong64.deb
-    digest: db7432b8d496c1ae3c742425e22524ad7bfd0561423af4995e60fd0f94413e9c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_loong64.deb
+    digest: 7a16c5c6e9f9002a14350ca92bcd645a7b2fa0f1dc2fdf0ccece81628e65e530
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.29_loong64.deb
-    digest: e13eb835c9f56811db2841a126393447f4f4d55b453f4c0b738a4f38a3dead03
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.25_loong64.deb
+    digest: 4ae1e9b1b54e2c23bcb5d1bbe82d9e8914d86c8f6bd849e564a72cf0401d6e47
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.2_loong64.deb
     digest: faecf60fdd232fce51578eee0380bfebfccc84cf7c00ae3d41af9a43572f2c0d
@@ -568,29 +580,29 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.2_loong64.deb
     digest: 9e03504ae093c9be1bec37e76dd97ef78bf4fe519320828ebb41096cebe47649
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.29_loong64.deb
-    digest: b6bbf1d692042bfcc78a1d6615b6e2f0c672e7d7d28d8fc3cdb80f6ff37ce355
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_loong64.deb
+    digest: 55fe88c9f524afdbbb25ca361b1bb5d508848d94c9fcf8add1f9559ae717812a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.29_loong64.deb
-    digest: aeae39e61bb48133d83712b194eed1b0186921f5e8c4dad8b5f9cc654226a6b4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.25_loong64.deb
+    digest: 81a053ed14e32a37af815860e1a3f77c06c00956dbe840040b25098335b4e1de
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.9_loong64.deb
-    digest: 0dcae6ca78fd2b49ad4a66ba9f41332179c763aba5e8a8eed46ebaf2660e3c19
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_loong64.deb
+    digest: a33416dbd875dda49e387dce675dfbfe364eef8c0237ed869714535deb97987d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcore/libdtkcore5_5.7.9_loong64.deb
-    digest: 01b13fba1393c7b73fe9bde740748d54782bad652c7902c3c037d2501660d661
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcore/libdtkcore5_5.7.5_loong64.deb
+    digest: 5535d463111d197c4cf73a7de4820acad5f2221b536dec3420e266b1f3a23f67
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.9_loong64.deb
-    digest: 34e8a5aabd8cbe9cbf0003b05dff44ee9160312a0f9ccfa4f50226a609a2909c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.5_loong64.deb
+    digest: 7e6f8fa112dcfc39ddd784f68cb20629ac9fdf8a014035c4233fea7d3afeafc1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkgui/libdtkgui5_5.7.9_loong64.deb
-    digest: e09914cfde91f188a723dca55c629666b98b3c28495c0c0c516780a16dd7fdcc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkgui/libdtkgui5_5.7.5_loong64.deb
+    digest: 82709bdbd229ddff21899ed70fc00d520f8ebb5ea2f44e2e16421a2c9656a5f7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtklog/libdtklog_0.0.2_loong64.deb
     digest: 8fb52bbaa8b7e67ab7014d4a251a21adf61b57dbf6f926878324b76f453dd2b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkwidget/libdtkwidget5_5.7.9_loong64.deb
-    digest: 8f02d07ddf792bf5f290e8f1fede142c0f4c73840cb597d59804e0e18d4a2905
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkwidget/libdtkwidget5_5.7.5_loong64.deb
+    digest: c1bfd6954fa4498712c1299080e0610646452a3ee8d215c1b9a824efa7274e33
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_loong64.deb
     digest: 851c5523af03e9dc081aa14afbeade7eeb1a21de5597226f13e0dcbed4a6ade7
@@ -622,8 +634,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libext2fs2_1.47.0-2deepin1_loong64.deb
     digest: c460fd2821af24b6a198979bfbda6c4cdbc31055c5e8d9837c5f0961d5b69dc5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libfdisk1_2.40.4-3deepin3_loong64.deb
-    digest: 5b6d4f84f83069f7ab18957e5a2d84f21b0e65f9bbb5d36a4d77af2cc0d51088
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libfdisk1_2.40.4-3deepin4_loong64.deb
+    digest: a7fb4a3586ad9334603e72d82636aca79628a42dade6a484932e5cffab9cf425
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi-dev_3.4.6-1_loong64.deb
     digest: 864ef36cd80bc0a9fadbdafca5a5ef05ff92458f945bc1c20753d7635d8f17b7
@@ -790,8 +802,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_loong64.deb
     digest: 3fc95b46c6dc87a3991386255c381d00c68a6ae6bfb4390ccb05f8cc61949331
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-qt/libgsettings-qt1_0.2-4_loong64.deb
-    digest: 4a5aa6e4989db5d4632e7e26cc9393dae8c4973796d4e377bf077d529615afa1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-qt/libgsettings-qt1_1.0.0-2deepin1_loong64.deb
+    digest: 647d808660c8505811549a3570779473f66835b8611aa76444fe8ea69fed043e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_loong64.deb
     digest: a74abdb1e7ddf88624513747e6591d1c799bc8774187470bd05d8d489834d596
@@ -964,11 +976,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmng/libmng1_1.0.10+dfsg-3.1-deepin1_loong64.deb
     digest: 501c91fa0ba7cc9f6bceff658ffdba2323039a590719a2030f2dd37266d296aa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin3_loong64.deb
-    digest: 62e45ce83e87a0232a104b09ec4e286c9af5b6105f47e37a694495da1dda321c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount-dev_2.40.4-3deepin4_loong64.deb
+    digest: b6a33875c9e10005da90db18aadaa4f044f4b694ccfe0b69973a41e881d4c104
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin3_loong64.deb
-    digest: 0cffe685b427d807f859133ea8c8ef6a196fe8cf237bef045577d6b8f89c180d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_loong64.deb
+    digest: 31a69b95233506e4afc628618c8fc0b9ca0c1cd0b69f97ee83e6bc5f7c17f6c3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mpfr4/libmpfr6_4.2.1-1_loong64.deb
     digest: 441bc4890aef4c3f38181d961d98e571892f2f32a2ba38b27323d36cd26c233b
@@ -1081,8 +1093,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre3/libpcre3_8.39-13deepin0_loong64.deb
     digest: d301118058e8ef3637d4710e3155b0700e1d372546d412a6fde28d3c0326c6a9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10_loong64.deb
-    digest: 04a865c6db98c65a2a540eb254174d4c012db34fc3b333ed5649fecedbfd0fbc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_loong64.deb
+    digest: dc6587b5ad4bb6a51f30edd225d1aa4d0f2e5c24107aeaa8bdb41e13f2136fd5
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_loong64.deb
     digest: 7fa4ed870a512323dc2bdebb32e85ab5c08036153b042a932beec468b3ba6089
@@ -1096,11 +1108,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_loong64.deb
     digest: 711fc166523e536c981def0bc709970f34be02ed60226bc129d2b1911b4ac46a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_loong64.deb
-    digest: abb634edd336c74e93bb9112ac7fe218e7375d824deb0d9eab295bfae60c9708
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin6_loong64.deb
+    digest: acc908348a6839f22e8e4076c42900542a180ffef9e331b4a93631164329431c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_loong64.deb
-    digest: 75d55921f9e8cb11b3f474a947dba74198b19a04b86aa6aa6b62f89c30b19458
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin6_loong64.deb
+    digest: 313bab65ae23545d7eaf34d2d0cc5321bc3d51e7d46ad1aeb63bf45b9ddd7c24
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt5-1-1_0.200.0-4deepin1_loong64.deb
     digest: df56466410622da67e80643cb7071bc04278d3428c40e1cc394b33d4528774ff
@@ -1126,11 +1138,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pugixml/libpugixml1v5_1.12.1-1_loong64.deb
     digest: c0b1583229b0598d53f538621d5664f544240877b106c0236906a51089bfbdb8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse-mainloop-glib0_16.1+dfsg1-5.1deepin1_loong64.deb
-    digest: 4a6e8e9486f0619f7bb4fd7b7ce86d4e401d7c88d146c86f3030f4cd59cf5449
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse-mainloop-glib0_17.0+dfsg1-2deepin1_loong64.deb
+    digest: 7f62038322d009f88b109e852c05c713884fb60bc6e41130a855bea60a2e862e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse0_16.1+dfsg1-5.1deepin1_loong64.deb
-    digest: b5c627561d8420b2cf208fd15c4175e61d122fec8878052138f1e827dffdd7a1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse0_17.0+dfsg1-2deepin1_loong64.deb
+    digest: f88e6830b6c1c94a8c0c337d6f79ebb19c2bddf0eaac23be7a0c15fce8e833b0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_loong64.deb
     digest: fccfbd0ff96d62aa2476f942b4e819b2bdce28f714ea360e036da7a0b3732597
@@ -1189,14 +1201,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5xml5_5.15.8-1+deepin9+rb1_loong64.deb
     digest: f45d4ba91c40379ac1cc73ca3b2ec004d11cc5f4737da6bed7d4aa91dfdc0c61
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 40afed06ff68037f3439fd57e8f362312c9dc15c6e34e049d6dc8b5bfaa87b9a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: df1fb644c6f18c557df389f7c8caccb8041cdbcbb3ba64cc4bdf5bd9dfcf95f3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 919d61879c77cdee9e8b66ba67d13ceb857166d6868f05cbbf2b71563f5ff007
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 05d37808475216a0a62fb277a78a21045f6a3371c9771eb614a38e175c67d861
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 45b90df13f986d76062d3265edc38c1d71fdcb5f3ed24ad35827210d9c1d8ca6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: b4bf3ee86fcbc0055e09cddc5cf75dadf7f2d92f2991207c6a0c591d9ddcf3cd
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
     digest: eefebd3f3d07b0f7d2f89e0ba469128aba20e0a1093ee0cc1853c3ddbdfa8616
@@ -1204,23 +1216,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
     digest: 0cb93130f4822644f809425794909492760cee0cc6c3d5596883a07edfbf9993
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 3406748fc8717befd193c722f67f6a26390bea5bd94e1143bba56f8119389e92
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 6512d39f8b25de932f919e8c1c5f6819ca71277f4c8a2ce5590ae347b98ca552
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
     digest: f748a917685218c990c97766bd2e9cf73caea758ba095bde0c76aed5d8b2c14f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: d461d93a38cd6da20ea983d3b338d7dd455e2aab09e56e681bdf4debde12856e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 32d4331abcf04409ac6526eb631f53c4d4d78e4c284441f6f22a468f17290dca
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 695e83e5470721abab1e3a99a0e240f4bb56e7ff7a1e29aa90c9f58a14914d62
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: a3d00166167d5a06e1fbb75780ca2965eb064eee915591358584a7feef57968b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 4b9acb93be2351871eccf59726de141276adb82b93b3b5867d60a0269ca2e3eb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 51d746486ddd8b214d7078de53fcc35701972f22cafd0248368176e06b80ea10
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: bfd7c6f191d6d0b8e66e75bab2ee7b487082e29e742070e4da77c32ae0359c52
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: c2cd48cbfdef345b85b35d08ada160aa696a1b23afe9f9a224ad2fd9ba7c17ec
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 31feabbf3ad584c4c450c37b5abb61ee289e05b11bbf04533131075201387b35
@@ -1240,11 +1252,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 889af35681f2708a99b089a4c9aa5f22e487da2125af9132d3f0e7b579b408fd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 7257b9beb4e89800194a7d9d4b966de5db84057cf8bc76abd7f6e876390a00a7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: ac8528c19b56097b2476dce90edd35521971fab57e90fac1e44545866acf2e00
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 4c0318f52bea415c07495e5a178d0838f8eda228a7d3511de44a8f08fe8165f7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 34291f35a8454f65214fa6ae65d31569edb74d581aed75bd502885f575e20915
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_loong64.deb
     digest: fc8cb023930b048f2caa531b913d991b4690a9f4692a9e4fbb423618ec67121b
@@ -1252,20 +1264,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_loong64.deb
     digest: 7a0239be93289e6b8d54806f5ffec75a9f4aea7cee0af219fc1932e64abde72e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: b776c9f55580c9c220e55608ab9cc6a87f89bfb3777b94b6ab6eda891d6655ae
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 11eea51f1f01f37a4fecad877eaef15584bfd9792fa5cb6ed74bed8dce2119e2
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
     digest: a4651ca09a7927998b556155807a65a4b68d19a83f8a3a0907e4129f0ed983a3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin4_loong64.deb
-    digest: 57068128d34bae2f408d6d8ca07061a6f034327b67ed03f27fc1e9aebff727a5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_loong64.deb
+    digest: 7637f2f08e271e14a5b05007e2fd18a8facc2c6fc3f29fe1ba5e2c5ea0d037c2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 611c0fc9f6ac208f03a62b87b2fc058a3495f1ece99334394998125bb691959e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: d3aa28809160e26462914fc87cd6b4fcb84bb59c9a925d864811c0fc8ab4a1d1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 1608a64b3742c08445346120665e897f55214abacdf4cc641429748bfe0de3d4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 26a96679e3356a3214126b3f58b1c6a2cd448f955925733340fe6fc1627ca7b9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/r/readline/libreadline8_8.2-3_loong64.deb
     digest: a1c114f0856366970ce731783250b16f1a600a917ac54eb45b3fc765a7dc5e8d
@@ -1288,11 +1300,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsecret/libsecret-common_0.21.4-1_all.deb
     digest: 2c12c067604e4872a281ddd17347c2a8bfa35ec65c086d46aed37414786205ab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin2_loong64.deb
-    digest: 704642e23cbbdbae01b29f6f6e9d7e8f23431a4cc5f33cdf74d7f119fcd12823
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1-dev_3.5-1deepin5_loong64.deb
+    digest: 3560dfdbcf90fef6f1fe16715e1bc7543a4e84b8759c58f71db0d93054bb7d49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1_3.5-1deepin2_loong64.deb
-    digest: a19a49923398b268c9f2f8e45bca89a70779d5b1b788f9f295e428e731868fe6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libselinux/libselinux1_3.5-1deepin5_loong64.deb
+    digest: f03e930d7d2d49c1d6355bce0b584177d61403d2e181c29767f2d853b716702a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsemanage/libsemanage-common_3.5-1deepin1_all.deb
     digest: c4fe4277d3df3d1bbf39083659701e5f4f9857e612ef7f1185e45eedc8f27047
@@ -1327,8 +1339,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsm/libsm6_1.2.3-1_loong64.deb
     digest: 9af2780f0816a5e2c10bbbe3abb974ba236ecf0beef15a49040433889c678847
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libsmartcols1_2.40.4-3deepin3_loong64.deb
-    digest: 1c693a408aedebbb87fba89469d602fb170daadd89c349de4c482e5d20138392
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libsmartcols1_2.40.4-3deepin4_loong64.deb
+    digest: ae6bad0e0cebcf3ad3d742ef19aa053abd5a072291f40ffd5405882df0b53f77
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/samba/libsmbclient_4.19.5+dfsg-1deepin1_loong64.deb
     digest: 52e4ac1718b16731896e28d0791041765226b996b5519833b142470f3f12eae5
@@ -1420,53 +1432,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
     digest: b2217959e0d34e5ce86a75b82acb235e1b887696044937815544c576c7abc9a7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-mu0_4.0.1-3deepin1_loong64.deb
-    digest: 9ab1a7f2e07de0e3025492ca143d1e69e1e4c453470e947d0348fd657fa390d3
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-rc0_4.0.1-3deepin1_loong64.deb
-    digest: b89208914d899ba60581d0655be29c62843c3b903fa3c9b48b6f05550117d7f8
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-sys1_4.0.1-3deepin1_loong64.deb
-    digest: 3f4c49b6d25690e4a5f0250a9f90377c85c7fa9c76b42e4434a6091a2abdbe6c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-cmd0_4.0.1-3deepin1_loong64.deb
-    digest: 8791c36d30de64a15384e68fd6a2fc2c3d167a5288061973cc0d39bc69d2842d
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-device0_4.0.1-3deepin1_loong64.deb
-    digest: 3fadba5f2134b074e499226c9eb06f80e218c74d62c2869c03dc4f69faebf3e2
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-libtpms0_4.0.1-3deepin1_loong64.deb
-    digest: 06c6417aff996ee508edeb82df05df711bf43f3f22824a8fc6615b7ca91e1b7b
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-mssim0_4.0.1-3deepin1_loong64.deb
-    digest: f2d8119b8494daa4ac52f98c5fd35fc404911a5421570261ad1710979184cdf5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-pcap0_4.0.1-3deepin1_loong64.deb
-    digest: 7557f14d726d78308bb6d08ca9e6f8ef1f2e1a48c30cba1d29195b2ac824e1ca
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-spi-helper0_4.0.1-3deepin1_loong64.deb
-    digest: 932f888b0c1813b41714cd93c445d88082bc26a01764dd6eedbc1ab0de1d63a4
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-swtpm0_4.0.1-3deepin1_loong64.deb
-    digest: 81f59339be44c241bf1f24e96ed153ee7f91508603d9fb61515cc833393af422
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/libtss2-tcti-tabrmd0_3.0.0-1.1_loong64.deb
-    digest: fe25c31d63e3193b35d7c672e0dd1d03fbe1b786d2aaef3e6cacda44bc16e50d
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tctildr0_4.0.1-3deepin1_loong64.deb
-    digest: 823244e1fc3b4631ef7a8db48198d6b89761c9131f4b9d71210c9cc08443c610
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin6_loong64.deb
     digest: c38b8a0ff42b40be8af246363fb2a07a6cfe163d48201681f9e382612c998100
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
     digest: 52fe8c374d5b0f18d538139bb314839f707a1ee6da3090d411fb9c2aa9c93e49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin5_loong64.deb
-    digest: 59005c8ada767732a3dde353404e5dea685f0b96908674c1b692bdf000209f4b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin7_loong64.deb
+    digest: d0532027aebc7da453c7dc6d0613ce21aad5d00c8500a6d365742a59b8ec782c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin5_loong64.deb
-    digest: d8098b6082b84415062f7c94a6af8fd15e3f1431039ea05bdff749b7c9a80f90
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin7_loong64.deb
+    digest: d4a6ba31fd8f171c93ce40a51a41fd13b8a489d334edca5641993bdf5a8a23bf
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2-qt5/libudisks2-qt5-0_5.0.6-1deepin_loong64.deb
     digest: 4e16415b94708072da530835678134badcc0276e785d0ecbdb68f10062f20c4a
@@ -1483,8 +1459,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libusbmuxd/libusbmuxd6_2.0.2-3_loong64.deb
     digest: 93f38cee54950f407ed2734ad0758fa438e1751e43e8ec6467be021fa28fcee0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin3_loong64.deb
-    digest: 93cf3fe05cf36385470caa606efd79af211a5ea1aa6a07e17b2e301b647eb689
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_loong64.deb
+    digest: f3e5aa1a85b3ab2076819261a56469b215cb519efa66d6417065e1826ca7a6ac
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/v/volume-key/libvolume-key1_0.3.12-3.1-deepin1_loong64.deb
     digest: 49d6752c26177e2e3bb5cbdb1e4bd0072cc82f69ba1a02a357387b08d2478fec
@@ -1678,8 +1654,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
     digest: e200be025cd227c34cb852eb20d4b7ad0d371095fdba7b7c4febc7ea7a2221e2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.18_loong64.deb
-    digest: 847ec80484c1e84b8728d22bf97579b1195a243d955f50a19ed17b915cfade7f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.24_loong64.deb
+    digest: 48957a988f750077b429a1e8b7f54ab5a6563931d4292f750220078741ed8ed9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shadow/login.defs_4.16.0-7deepin1_all.deb
     digest: abed558f44fdd893df5020fdd787b2ee1b5cbc8b5e4b78ab4b01b8f1cc1aad08
@@ -1705,8 +1681,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/mount_2.40.4-3deepin3_loong64.deb
-    digest: 34e7c1c509c65a0ed43bafaecc75009fdb334bf2ea5d8d036609994b6ebfdef5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/mount_2.40.4-3deepin4_loong64.deb
+    digest: 3d336b1a11cd024f9abe976df0e079abc169608a20262029e47d4c96e516f392
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
@@ -1720,14 +1696,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/patch/patch_2.7.6-7_loong64.deb
     digest: 713a6fe43f8c66f410ed5eca4b57361868d6da0f05e2ef9f7300f7fe524ee2e5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-base_5.36.0-10_loong64.deb
-    digest: 2c2ff9c3322f33ec19ed0c0170001fde2d9ff60937d323f154aac0a1a660fe82
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-base_5.36.0-10deepin1_loong64.deb
+    digest: 0c82d65a772e2396c06bc94b1266087c4f490b0fccf8b55c47b95ed82b7e5ff9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-modules-5.36_5.36.0-10_all.deb
-    digest: 907542b9a413bd0276d5ef94fef77083715a692fd33c52ece44d11fff847bab0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl-modules-5.36_5.36.0-10deepin1_all.deb
+    digest: b79ccae8397e919ee917cd187b8be2d3b10eb598f43cf72a9d9a50c3d81ec288
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl_5.36.0-10_loong64.deb
-    digest: dc3b0b73a582471f146be8f35e39d61ef9046a2a4f3ee2a29684f8ed12d2a598
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/perl_5.36.0-10deepin1_loong64.deb
+    digest: 030b888ad983a63b0cec1e207f3f372abd6b61d64efbe23c781dae2af2634838
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pinentry/pinentry-curses_1.2.0-2_loong64.deb
     digest: 455cb8b3a11ea0caadec238ba0981204a4da2ccc12ca1235becbaf7ca21c935d
@@ -1762,11 +1738,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
     digest: 99aa344e806f799b1008841a76c4f83ad58f508aa7216f7df5adae3aa860fdbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: b9ff8c5ba70ea298a01eccd841994ca45a5026a3a1a65d28258428c36a6d04bb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: b2c23ea458f84eaf5df7f06ceeccf24047551cabc4abd35782060399cd2c8ad6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: a0be387293e7b23a2809cbba02e89333d751fcbdd7ade07cb30433afb85dd3fd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 4a50a0bec4830e8b4d5468af3ca9b8bb08bcea4892539c2133c6cfe8d06889de
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 352c93151474b4e0843755cf4248d5678df53a42e9058d07408427a848b52b08
@@ -1786,11 +1762,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtimageformats-opensource-src/qt5-image-formats-plugins_5.15.8-1+dde_loong64.deb
     digest: acad29301a55d860cb5f300422fbf0600f20d39dea780e9bce507f0a05c18f18
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: e52277f5f397d77f6b1331ac399ce186add0452011cf161b009e75c129a6b257
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 2e76edf66678b456d8d2772efd47d38a50c140d74084a166fd2faf1a63da2b00
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 3ef53c878d0a8599a7d692349a6023f653dc6775d9c2377b92f6a33ed937cba1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 6cc78a068f206bc90e8cea49b01dac72ac0356213fe52643cec12a23f6b82353
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
     digest: cf6fafc95fdce9f99b2bfd283100163a1c316fc596dd6ab9da30821d1faeb0d5
@@ -1801,8 +1777,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
     digest: 64b8adf192160cd12b0e63cba2d112fe0f0f361f83df2666c5017e55e5383fd9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin6_loong64.deb
-    digest: 939e00ffd3b27a7773de5081f5824c74f9e3e4e136d8ef2fc9d5ce99511675bb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_loong64.deb
+    digest: 13e2e5d5ae5fbaa5b971f6e5d4b48c1d72cef2e77af4344e7b802e0f4170228b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_loong64.deb
     digest: 8d025380c93576e65ed0941ed9b0a568d366c9554497570335f4426be7068545
@@ -1837,9 +1813,6 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-dev_255.2-4deepin6_all.deb
     digest: 41bec4491af5737e55f1c186ec8bd05d24611dfaeda7132354e75ccb6ea7dd68
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-standalone-sysusers_255.2-4deepin6_loong64.deb
-    digest: 8161d72f669abfbd1bf7d3bc8f47e7d95e40818d4cc6a02efddde6323d557ef2
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-sysv_255.2-4deepin6_loong64.deb
     digest: 204a94e1ace3a3835833361a0deda9e1711211fed52854943f9c5d4e600f7760
   - kind: file
@@ -1848,12 +1821,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tar/tar_1.35+dfsg-3_loong64.deb
     digest: 48cc0cc32829c68c7b58e74f141fe552f9a3f5c9e6da77ad54184530debc0cff
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm-udev/tpm-udev_0.5_all.deb
-    digest: 8305c01b236dc4838bfd5f3331c403ed344207b35808d4bbb76dd58471a65b60
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/tpm2-abrmd_3.0.0-1.1_loong64.deb
-    digest: d5c65b2b7e88f89c1147dc7cf4346236c71e1cd107fec1b40712c06210404d23
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
@@ -1864,17 +1831,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/udev_255.2-4deepin6_loong64.deb
     digest: 1b1be113e57f54eaacd13952a63f9cfbabd5c974e58e53cbb15434aa1905cedb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin5_loong64.deb
-    digest: 1453ebb5b92bc7ce64045a9bf35e6553a1b87bfe1d653da2d7dac4e3d536f94b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin7_loong64.deb
+    digest: be0645c72c2941270365fe915395f1d5013088e0fe317329152602b047171244
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usr-is-merged_38_all.deb
-    digest: a955d8f015290e7447210d049a362e3f04afcb82fcf1f0b4403d13df7b4f5fd6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usr-is-merged_39+nmu2deepin1_all.deb
+    digest: e8896ae20e16a3b4ab0ab4caaadf884de1c0056ff449f85ff1426415e8758a3c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usrmerge_38_all.deb
-    digest: fdc636985788b18a04cd15941a111fb2a73d3b56cf58c689b918345e6f003161
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usrmerge_39+nmu2deepin1_all.deb
+    digest: 544feca0992471720cd5648cf88b0241df5d32cf72c2037ab5d19fd617a15a29
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin3_loong64.deb
-    digest: 8b46b49065b50012004c9f8b663f31f0e6b375b3071646450e386d4254218161
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/uuid-dev_2.40.4-3deepin4_loong64.deb
+    digest: 8097f0f8c46e7619c944b22fb4160d60ac3b3eb5aab3d5ea26a7c83816ed24bd
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xorg/x11-common_7.7+23-deepin1_all.deb
     digest: 9a7643db11023a8bec126312edec4b1b7357b93416bdfbaf9b0cb8bc04506d49

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.19.1
+  version: 6.5.20.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
chore: Update package URLs and digests in linglong.yaml files
   
   - Updated coreutils and cryfs package URLs and digests across all architectures.
   - Modified dde-file-manager entries to reflect new versions and added additional plugins.
   - Adjusted gnupg2 package versions and URLs for consistency across architectures.
   - Removed deprecated systemd package entries and updated other package URLs and digests as necessary.

## Summary by Sourcery

Refresh and align package source definitions across all architectures in linglong.yaml by updating versions, URLs, and digests.

Enhancements:
- Bump deepin-font-manager version to 6.5.20.1
- Update coreutils and cryfs package URLs and digests to revised upstream builds
- Align gnupg2 components to version 2.4.5 and add new keyboxd package
- Split dde-file-manager into common, daemon, dev, plugin, and preview packages
- Remove deprecated tpm2-tss and systemd standalone-sysusers entries
- Upgrade linux-libc-dev and other core packages to updated revisions