### PR TITLE
chore: Update version to 6.5.21

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     font manager for deepin os.
@@ -82,17 +82,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/bzip2_1.0.8-deepin1_arm64.deb
     digest: 5fc6a22a0ad720a1b8fc7f8ef83ddfbb0c59bfa43ad383c7052cf2adf9f3d0d7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-3.1_arm64.deb
-    digest: 7483a0b744f9eac3d46e0744058923d7bef5512e1ff7afa6328ed7208a38d11d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-3.1deepin2_arm64.deb
+    digest: 3e936812ae06512d52ea56ef3d9f368da04be31cfc268ae1e96d52f2aeb02c80
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1+rb1_arm64.deb
     digest: f50240be45b9eeee8f6d27feb462e5fac2f6aaf88fdd9b50f66606ac044a2409
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2_arm64.deb
-    digest: f903e352cfc425eb6e8ac081e2e8df9b0a38977b57e4f945a49c640528f46ccd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2.1_arm64.deb
+    digest: 21e8a1333c52d71cf70f28881d01d4a6087ba19872d8d44245fd453af19fbf09
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2_arm64.deb
-    digest: 3e7641f32ee1112441b3aff191a988a5118390a358bc93870036cde92a973e58
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2.1_arm64.deb
+    digest: cbc4bf1ab75f244e3497e27fbd9a3b3549c5a8cb9423f186aa8dde6875c8d66f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dbus/dbus-bin_1.14.10-3_arm64.deb
     digest: 1897c8dfbbbfba645cccc34762612e60903f62caa3aeaecaf4fead01105f2c15
@@ -121,29 +121,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/dconf-service_0.40.0-2_arm64.deb
     digest: 3519e252c6decf5d942303ec032d0c56e23fd4eaf83ab2806af343d205445f5f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_0.0.1.16_arm64.deb
-    digest: 9dec686131aacd2b06c42a3b9a571e893874ad818122568de83d3cd97b55829b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_1.5.5_arm64.deb
+    digest: 73996d69cbee52621dd9203a6117d0c54f74bdb8a52adf67da7ae074fe56647d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-common-plugins_6.5.10.6_arm64.deb
-    digest: 6fd1831bd3393e707c33b1928acea17e8fc80516fad8b79f18952a05257a096b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.69_arm64.deb
+    digest: 49dc51c8e480b4be5e81bc005da73d535d8cc5af9ee074d90282d0446423d843
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-daemon-plugins_6.5.10.6_arm64.deb
-    digest: 87d4d18e1d15964883c5d3e38be7515fe9385c2402a6d525f344db313665d0a5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.69_arm64.deb
+    digest: b0513e9514efd12990910f07fb69532cafe9a9af259702b8cc7c1771b01c519b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.10.6_arm64.deb
-    digest: 370d9c201314b119dcceac84465ca18fce52005efd581be19c8a471a4e54497d
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-plugins_6.5.10.6_arm64.deb
-    digest: 2ba7397cef47e5c57166f1be590a07d9c05137e0c990c613d5dfc67c5ca1d1e3
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-preview_6.5.10.6_arm64.deb
-    digest: 0547dbd6dfc8c0694f5143300bbc789398e9036e8a6a1f37d53350105e69f3f1
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.10.6_arm64.deb
-    digest: 5b692b982d02affbfa8766625d0464897f12671962a702bef8ca3d68fa2ea3b4
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.10.6_arm64.deb
-    digest: 7e71414f79672851b01a0241b5dcae9bc126ff7958c28ba7d3666e692dcab157
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.69_arm64.deb
+    digest: b492bb71f0838cfaab2bdf97fcdb3018b9141220603fe5d5a687f7ba0080c564
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
@@ -163,14 +151,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/dmsetup_1.02.201-1_arm64.deb
     digest: 70a943b93efa2735c5b2584e0c473ac2b66bf981ed8c5e323cdd77adaa55551b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
-    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin3_arm64.deb
-    digest: 81d1a53d75115f01e303fcf8337493bc2850614b0a2e30b06b9e0fa67d0d5a80
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/file/file_5.45-2_arm64.deb
-    digest: 6417effcd187edf2c6653f343612e35889cf9408ec37601870ab3c5022c887a1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_arm64.deb
+    digest: 395526d8605c5a34c3bea89d6c32781d3a5625eae82b77f598835c09524f51cb
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_arm64.deb
     digest: aa64934dbf43b0dd0ffee2b7fbcce324b50b957b0a4f04c10d062a85d8847d8e
@@ -217,17 +202,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_arm64.deb
     digest: 4663b703fa834002da6bbd91431eeddad3eb2f235100782fb3cea7473afce618
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin7_arm64.deb
-    digest: ae48dfb55b4f7653a2409cb337444b659000347294637d75b6d3771e755c363a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin10_arm64.deb
+    digest: 3b0743eeaa97b139aed75f24128adfa5d8913a537f233389a1573b59afe97cd3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-common_2.78.0-1_all.deb
-    digest: 94bfaef9228159f8a2f366b9962e5bd82c9ddb53228b161d62c6f5d48ecf1c3c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-common_2.80.1-1_all.deb
+    digest: aa697ddbd07ba9e16391bd81f73661b2583859c8671d1ce92f28e6a870d37059
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-services_2.78.0-1_arm64.deb
-    digest: e77ac51b00d8e5571476315bdfe08e4dba8a739c7d184a5c0488a29990b2eca5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-services_2.80.1-1_arm64.deb
+    digest: da5d326bb6e8d166c11ef54ce768fd3ebfbe7ba7946b076543f7517e7dd7f230
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking_2.78.0-1_arm64.deb
-    digest: 71a35d0dcc2e793ab413991cf7fead4c725ff13a77e2d8502c6d21d28b01b40c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking_2.80.1-1_arm64.deb
+    digest: a51fda6d5ccdce9334b2c49ed05567fce5ff5a764152da889e3b312b87d989e8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg-l10n_2.4.5-2_all.deb
     digest: c9e04d548f5db44bf2772cac43a1fae57f0711e9ab939d0b8eaefa284f50df0f
@@ -268,8 +253,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gvfs/gvfs_1.54.2-2deepin1_arm64.deb
     digest: 491735ab513eb73a1a08e8a02da3f726ffa54e7aa636b426264b99824f05c8fc
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/hello/hello_2.10-2_arm64.deb
+    digest: 305f41ce8a0e654a60ceb9433c21516c5570d0c0b297524906d0361b63a0630e
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
     digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/iso-codes/iso-codes_4.16.0-1_all.deb
+    digest: acd8d976f1a757da000d9ea9405fdf80194a6275fc93fc472e1df1dfa5b301a5
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/keyboxd_2.4.5-2_arm64.deb
     digest: 7d24bd64d15c6c73178cf4f56f4f85640187dce3214d2017eadfbaf17b0db009
@@ -277,8 +268,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/abseil/libabsl20220623_20220623.1-3_arm64.deb
     digest: 4e7d08584337a95ccbb5167513fa590d5fe4614eb17860b743e190a49bdf9541
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-1_arm64.deb
-    digest: 51808064361bdae539f985645eaee59b53c703b293174f761d996b27f2b8d860
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-3_arm64.deb
+    digest: ea023a815c9257d7d4f2028037d8d2b19009d9e36d6ae7d6cd5b20ad38e90565
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/aom/libaom3_3.9.1-1_arm64.deb
     digest: 2ac174ee086466df9fc130a81c5f9aed2932b8de1b40ef60bd116a549d4af57f
@@ -307,8 +298,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libatasmart/libatasmart4_0.19-5_arm64.deb
     digest: ca1710db0536da3a7ba9549e6098a0356d9bfbd988bdc1069ffd4263941746b4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/attr/libattr1_2.5.1-1_arm64.deb
-    digest: 2eb5cf5a1240dd06a37f8a529d5982be1426bf44d38543746d1bbe44f7ada2e8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/attr/libattr1_2.5.1-4_arm64.deb
+    digest: 5035457363acdc39a6d3b9b79aec645671b733078f3623c201ac3b31fd9364f7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/audit/libaudit-common_3.1.2-2_all.deb
     digest: 5fcb4f437655bbe179c280be56fdc879d317f6ea6f3a6b865c9fa01a314fc8ca
@@ -331,20 +322,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libavc1394/libavc1394-0_0.5.4-5_arm64.deb
     digest: f4c42a206e22196ffae860df9721e1b1dd22a1a90e6879ec47e0f02e4215ce70
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin0_arm64.deb
-    digest: bf6905458722a383dbdd69c2fe894b4d7d842d309713d21af9a8bb6a06aba779
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin2_arm64.deb
+    digest: 8d24a40a05ab5ff7dee8d5180acb049c984a18dafd632ffa23bf1c02dc4c1d0c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin0_arm64.deb
-    digest: 6d7ccc33fe58f373bfaff5a85c8e2bb21b3edd79c808dad0c1d05b66c01f0588
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin2_arm64.deb
+    digest: 6187c73e1cac5a58003fdff97e19429f79d3a4ae527e37b66022614289d7bcb1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin0_arm64.deb
-    digest: 5b4fd7c461f9c6cd228e238f1a4587b336ef3428c7d824a4548daeef1d0044bb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin2_arm64.deb
+    digest: c1aed93e7d684d49f52f650f8af8a954f1137b24fd037573cff9302c05e65779
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin0_arm64.deb
-    digest: c19ead041d82536839e168daa2739df61394046648736559ff840c42f328f08e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin2_arm64.deb
+    digest: b309056f6e2f2b4d21606204ef7d585b3c087d8dfe7d88d79f46312a9f555f2a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin0_arm64.deb
-    digest: 4f26322eb48a311324e5473896ed167ad1f281d7266b4a35034fee1c56f4f62b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin2_arm64.deb
+    digest: 5d0554f80e21505d1c8f016ec911de7adbf3692150995243d806c68af667591d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
     digest: cac541f3cf746d006b71a08f88364b6743222b8956fda9a7cbd35ffb1cf32ed9
@@ -364,35 +355,35 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto2_2.26-1deepin_arm64.deb
     digest: 3c8466f6738646d0c955b1aca4d81febacf40f6448e8dfba4439ab381882649e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto3_3.1.1-1_arm64.deb
-    digest: 85d9c9f8146dca8e7487697681ea13c77a43ac67fff5466cd9184a4d6994dd33
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto3_3.3.0-2.1deepin1_arm64.deb
+    digest: 7a37df3dd907dfc2797a1c854aed8186ada280045dbc535db37e9fabe12ad8ee
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-fs3_3.1.1-1_arm64.deb
-    digest: cabf7c247d403e1b18c69957f22e0caab49586c91ae0fbeb3d4956cd31b5b4d4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-fs3_3.3.0-2.1deepin1_arm64.deb
+    digest: 7848c3adab6df4e251786a6c141739682619b69d28610d12dd453d1cbc89613c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-loop3_3.1.1-1_arm64.deb
-    digest: cff5227ac4b3bf64cdaaf15d5613830dc5ec45f151142e4cfb1ec028fc854597
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-loop3_3.3.0-2.1deepin1_arm64.deb
+    digest: dc769b007732c706bc514c12db334da1d0e702e182b1c12d767e3f186aeae6cc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-mdraid3_3.1.1-1_arm64.deb
-    digest: 86ebeae4d01fd58d0cfacdc90fdc2eabb12d798d87a58850e5b97d7688db9831
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-mdraid3_3.3.0-2.1deepin1_arm64.deb
+    digest: 80f480002347e4d6f66c86caee16a48a7a3acdf31521ecfa16a719aa5946d8a3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-nvme3_3.1.1-1_arm64.deb
-    digest: 2a89c460c88118c29713e564b1c365b882685285cf736d9ed57efea486630a48
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-nvme3_3.3.0-2.1deepin1_arm64.deb
+    digest: 783ff248f3f74a8c7b3cd5707280dffbf8bdba20cf1d899672e23df154ee2e44
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-part3_3.1.1-1_arm64.deb
-    digest: a551b1a4a7f1c8b420b01e67a19945a6a0e95865587e07db00a640a26745ba67
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-part3_3.3.0-2.1deepin1_arm64.deb
+    digest: bc5099fa568d90a9111ab5b66ca978f4363bfdf64ab5cb8c6d5f201036c41368
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-swap3_3.1.1-1_arm64.deb
-    digest: 79930b2d449a659230c2c2f3770ab2c54c8fc0580e76f220d1330f1866eafb86
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-swap3_3.3.0-2.1deepin1_arm64.deb
+    digest: 1a49456dc02a03f83258f24ba453890ee8810695c3cefd2f60364d0b179d1277
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-utils2_2.26-1deepin_arm64.deb
     digest: 997efe02a43f71b1d78c575b31a86937e8d97dbd45fb91e2eaf82f32da5200db
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-utils3_3.1.1-1_arm64.deb
-    digest: af6190eed20fdf085f6bb7674e0cd4f188ca5f0d74d1b45c770588199712c49c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-utils3_3.3.0-2.1deepin1_arm64.deb
+    digest: a234d4610c8f456f2f490fa411d53fb965e5c496af57ac5b8f4a83447e231d50
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev3_3.1.1-1_arm64.deb
-    digest: ab7de0afc9925a7a77c1c2f55d4a937a992b85b248703272d3ae06151706f541
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev3_3.3.0-2.1deepin1_arm64.deb
+    digest: 77f1b1cdecd545f7ad28cbf2a0d43796bdb30a10d7c09de76f0212739a936b62
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_arm64.deb
     digest: 321b50e4ee0efc4aaa9e67168e4b88216733e1c012d269e6e9f2c04941a66ec0
@@ -463,6 +454,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap-ng/libcap-ng0_0.8.4-2deepin1_arm64.deb
     digest: 7dc863e432010eb9425dd5f5e69431cfe290f14ca93b4969111fbf96d3110eb2
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2-bin_2.66-5_arm64.deb
+    digest: 50f7cde5dc2b83935b7f99fa9955ee18b4bd8f5ac87db50e2335445885d52c55
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2_2.66-5_arm64.deb
     digest: 6f196062b90716256bf2a57e919d18c74eb6cc19d98f1cf88e603cbd8d68b188
   - kind: file
@@ -481,8 +475,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_arm64.deb
     digest: 39486fac0b8bd52f8641e2586befaa00aeb6a03106f3b6c99e64039c8e7b4a6e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.15-1_arm64.deb
-    digest: 2dae901869e9a50f832d6168942a0c8fe6e643e4f9f56f161cb212a6ad59c233
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.18-3_arm64.deb
+    digest: 8ba115a3752e7445e5c684614ae1a057419721a601c4017ee0cd442414a3231f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_arm64.deb
     digest: 544520612dc6697c5165126dab9ec2cabae88d42678aaa5a762674559a6ace92
@@ -505,8 +499,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_arm64.deb
     digest: 037584e67001e5de6f78c0d3acabe70a7b2e7dc592252ae0d9397c263c41c9f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2_arm64.deb
-    digest: 323561981b604680b9e72c6ab1d36c51bb5d95795759b03e9705270ff7998a20
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2.1_arm64.deb
+    digest: f0f203eb6009c93788a6add455c76c3ed52211069d6b559d221842ff6a1919ae
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_arm64.deb
     digest: e34f53bdde8f49dddfcbd7daa63d613f5c71b92d0e79683b500c8bccd0866bb4
@@ -514,17 +508,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_arm64.deb
     digest: bab638b4aed73a4a9420a17ec27f3120ff10404c3d3e6e1a66fe023fa8a44121
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_arm64.deb
-    digest: 1557184d0ba255ee05b5c929396c4c925e10782f9cba74f3514f96d3bf581ca1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_arm64.deb
+    digest: a72f4563335d016cf4a0f8bbf5d26b0ed90f554a8ff2e6b9701967daa114569b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin1_arm64.deb
-    digest: e9754a238fed47dac0e3e6255697563494f6ca4b58313bc7f6183d4d0995d32f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_arm64.deb
+    digest: 534a9ba35f69f93d103edbe1736a7ffe7f2b84a8e3746889d78feadfaa507d22
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_arm64.deb
-    digest: d0a1e93cb1b63e0040b50c924c8a7c9464494ef3547447913584d0a62999590a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_arm64.deb
+    digest: 01509b9730896972e09e937a3d27ae4c9cea9b536b0296db37af464314490934
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_arm64.deb
-    digest: 12003d3e5acd0a1c379f81e075b6171fb784666763813528fd18189beea9735d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_arm64.deb
+    digest: 24db7f1a3f57d436a532a215e32df71a9df3ff19731d81c7988c0d77df86b692
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_arm64.deb
     digest: 4fcab53e5e791e65cd9160e0e77eacec106bce0f5ea0567bcb1387b362101488
@@ -538,6 +532,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_arm64.deb
     digest: ed96097c7b23c3224e448f430d8a6bee10a2ec736088eca565b99146b72d82d5
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/davs2/libdavs2-16_1.7.1-1+dde_arm64.deb
+    digest: 1a7dd44072b582c34e49f0972fb97c2e9b861ee03ae04c660678c09266b9afce
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_arm64.deb
     digest: ee20a140ab90ce9fa2ab045eab6195b426d5c441459a788e15966687a1d57221
   - kind: file
@@ -550,8 +547,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/libdconf1_0.40.0-2_arm64.deb
     digest: 57f0d64bf483877f4c8e4bec0eaec73227d30795dba37aa6ce726b6816c0abef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.10.6_arm64.deb
-    digest: 2c9332350d57f08920935287dd86aac5e9c089607a9f223e7ea7697e1605b70c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.69_arm64.deb
+    digest: 13b8ca924353f9e25ae78aa287a8bb141cd59341cdb49c779d58a7b403109889
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libde265/libde265-0_1.0.15-1_arm64.deb
+    digest: a13a2d2c3ba13b8f1d8bfd8b657665d3b1666c6fc954c16c8cec972e5af01c47
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cdebconf/libdebconfclient0_0.271_arm64.deb
     digest: 1d9347b2ceba10b302d2c571bfbda6567f159d546a14e99e300a07c2dbe1fb94
@@ -559,8 +559,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdecor-0/libdecor-0-0_0.2.2-2_arm64.deb
     digest: f99b185a88446c1b1e4607d2c5eb79ccac6965174ad540a28e4d6ea572378740
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-pdfium/libdeepin-pdfium_1.0.2+rb1_arm64.deb
-    digest: 142edb9aad7713d97a16acf694f33905f3fb2dfe20d3bc8571d7755e0ec86a4f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-pdfium/libdeepin-pdfium_1.5.3_arm64.deb
+    digest: ba7d98ea8b937be9be43342bf0219ed42070f10273619a629e623df727ab064a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_arm64.deb
     digest: d5e52d889f15c80ffe7214c06605d831488c2650ec00d7c9eb9b50ebbc108133
@@ -571,47 +571,41 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_arm64.deb
     digest: c323c31508b8e23cc1b44a3a45920288f17d6cb3a6ae7d53746a3bb2a9a982a1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn-dev_1.3.4_arm64.deb
-    digest: ccf577cceee876556757c8680cbb45d74667212891d1a83ba5a7c0a56ab1d50d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.69_arm64.deb
+    digest: c8f7cf58fa73811d1b176bd7facc39226cddb991be5c341fd9f91a5ad1f7aa9b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn_1.3.4_arm64.deb
-    digest: 035457006627e6bf449a714ca000787a1e1441c8434808288c344d8afb0db3cd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn-dev_1.3.31_arm64.deb
+    digest: b5aec30e7802689f86610df227a51bf3e64675a872f2542fdab1aaa6bba29c72
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.10.6_arm64.deb
-    digest: f32307c6bc7971ce992f333f499c0a3831538e657583d2f48942e129ae28833c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.31_arm64.deb
+    digest: 3876ac5ee7b3a08ac066a4427d26a4bed2dcb8d3bff7750f96b6b27e585f4e0b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io-dev_1.3.4_arm64.deb
-    digest: c64e20bce86727c5f20bed5b948305d298d94d957a0dbfa01594efe756f0452b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io-dev_1.3.31_arm64.deb
+    digest: aec561bcb897500213f358ce2454709f57f30f5f86824e9e45f3befa6dc668d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io_1.3.4_arm64.deb
-    digest: 329851fe9b94e65e6bf7e7fe89305977b7b8ce41d7518725add362ed4f42fa7d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.31_arm64.deb
+    digest: dd56c60397ae436a8e5fe3caada495b9a2a78902600ec9dc47e8774d697cc0f2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount-dev_1.3.4_arm64.deb
-    digest: 013dd9b04293671f6bd779ecf3b63e3ddef0517b1d3f61fe026b61793fe34d63
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.31_arm64.deb
+    digest: 18670128ea0140e7e8e3bf95fc83261daf6ac2874b9f42522b20a3973e65ba74
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount_1.3.4_arm64.deb
-    digest: 82b69fa13d4c57cacce14463e1fbef27d789b7224afafe4f9ab0ebbba3a576bb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.31_arm64.deb
+    digest: a6f5356b4feb451d52d63bf7d6215fda1fd49022903a3485d2b7da709b3987c3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.4_arm64.deb
-    digest: 03619a4f69f622b42f1a4957e6351791e037a4bd28022e9ded1db4df84231beb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-search_1.3.31_arm64.deb
+    digest: 9a1a5dc487ccae38d6c4c6eb832f5d0316348f2d72f0935cd0369574c55ed072
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.4_arm64.deb
-    digest: b15fb7824472e89cfb9112af574ec9ae1aea8e015708d6035d33bf593a5b4626
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.5.17_arm64.deb
+    digest: 25408acfa53a0295062e2a284aa0396556d701e76cc8060eb8351484be1083ad
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.4_arm64.deb
-    digest: f182df83fe3654a2c0bef8fbf2e478c47dcaad73805593101421fb2ad0a806ed
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.0.13-2_arm64.deb
-    digest: f4ba9f358ff3e3a6c76f4c036739cdd90c5ce9bf74e34a8210bc9becc4b7ee98
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.10_arm64.deb
-    digest: d6c3d26e5203476f36a47dc8d108d9181aef75073e8398acc60ea8072db88456
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.21_arm64.deb
+    digest: b680701b4a5f9d42e4eb1bc6e833efa54332a1c78ea2b76a9f36557231445680
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_arm64.deb
     digest: 78e9245e377c8f61009cc60d2b55001aaddd7b656fceb916b3ba8f07344251b7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
-    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_arm64.deb
     digest: ea011d2a1b77d97ea5d538786dc3aece9a24e317489827cf5e4dfc6032cb61f4
@@ -625,47 +619,38 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_arm64.deb
     digest: 6c900feb79b1e5f847a5b9f53c6bda3f6aa12a9abfcf106f872a3812ef78bbc4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.25_arm64.deb
-    digest: b8693fdd024188f811597e28d7d7e03dba17e811711883716b7ff76376801e02
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_arm64.deb
+    digest: c9472936e80c216fd09a2e9c5123ca1cedea9432294261178883d8a952c7f99b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.25_arm64.deb
-    digest: 3442eb4010d5176f27e5062d6fb07f1d8afca80c59375f9c37aa65eea62a727c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.38_arm64.deb
+    digest: e8a717160caa08f795f1f567ec57d2b661814e8084fe8d860d94f56a3e05ea47
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_arm64.deb
-    digest: 5b30d2ade934bf6b80f4fd6e9eecf7549d44e9df70c8e97266b720811c90ffb3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_arm64.deb
+    digest: a80d44bf31660feda6ed1208ff5521335b7fb201da93956945359b0549a8f7b8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.25_arm64.deb
-    digest: 34a82a6a255c9d9ea99e12432c047cf0efafd61101a90ef319689d4940fa9767
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.38_arm64.deb
+    digest: 1594a4003d6dfee6d91d2ed7a0af502f4ea38504631401f3a1baa5860c70cbb6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.2_arm64.deb
-    digest: 0e714a576b19f5a920d224ef1a1877e93c4b8aea1e49eba99df7316c72319910
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_arm64.deb
+    digest: 0d2a9910f59a67a92ae67c644d2a78df0476a710a1bd4284869a3e3a993d9734
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.2_arm64.deb
-    digest: 67e687906a183922d6e510666f7637c45946e68f61bc4f0ce7fc2a840aaff3e0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.4_arm64.deb
+    digest: 01a779e198b225da4069a480677d4e7c816f04309c3ce70829411b4bbe8b3a96
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_arm64.deb
-    digest: d77647f1b8ddc312041ad612cf3c1343bd3fbd8193b2a72e8bfae9ba64d4053b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_arm64.deb
+    digest: f1743536d71c1610937a548699d0bd40692b3ce34ce5ea591c4ad919d6ae1b6b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.25_arm64.deb
-    digest: 146b21a131932f6ced35c1b74c912ae9794b9bdadbdceff37babece4c9eb90bb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.38_arm64.deb
+    digest: 85c4766d67def86998b406625bc1a22eacf910a131bf1006735af2897efe3e1b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_arm64.deb
-    digest: 11cf667515ce2bcbc7ac6ae27bafc324f6cea17772d8e7aa43cfda6288713e67
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_arm64.deb
+    digest: 766177ea4c8c2a5cfdeb1b3eee5b31b62b72be9aa06744dd7a6542cc888c494c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcore/libdtkcore5_5.7.5_arm64.deb
-    digest: 5c0d695b2d9c3190db589a7a84986f7dcd9ee54dd7b74eb1b592118d9a6fd052
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.18_arm64.deb
+    digest: a34538990a42f2be5b28b198b3b75d96ab6edfc9b850824c8ee222305f42c699
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.5_arm64.deb
-    digest: b468b48c1f8fe5b98f4294edbe3b757726fcefbfdfb79ab54d3adffc293d17cb
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkgui/libdtkgui5_5.7.5_arm64.deb
-    digest: 75c83e7d6e5c2fe51ef8342b3532f487abe60f0163cdc6c3a9a675a08abbfb4b
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtklog/libdtklog_0.0.2_arm64.deb
-    digest: 44c162ceeff309bd16de1684f8acfbda08b8ed9607cd989813e91fb945af0d5b
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkwidget/libdtkwidget5_5.7.5_arm64.deb
-    digest: 0bb6d99f853f3c4b37f76c992d8482a950b4e32eb365e1283f41ffeb9092952a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/duktape/libduktape207_2.7.0-2_arm64.deb
+    digest: 514955337167c41ebe2aec0cab0cf30ebf6f47cb7893b0ae1db20590c3d29ad9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdvdnav/libdvdnav4_6.1.1-1_arm64.deb
     digest: f5e805b74f43e619521c8d270fd6cc234a231bb0bfd15d3c626dc5653b28fff6
@@ -673,20 +658,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdvdread/libdvdread8_6.1.2-1_arm64.deb
     digest: 64ccc5ff0bd969d0cd933620c7c46d67fde87e1191b1a07c783564a18834c819
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libdw1_0.191-1deepin2_arm64.deb
+    digest: 9507c8c6c5084962857336fe972dc2b4de79cfcf36bad3065d124dd992f17942
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_arm64.deb
     digest: ba394c531b520e3ee365d29c127505bce3554df15885dd53dbe9a9deee191326
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin1_arm64.deb
-    digest: 1242d431d868c4ab91b1eac197b65ad7fff15b43b723870cfd9f5fe3b6e4711c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_arm64.deb
+    digest: 426be89c01067a002f4d4873688297fa1444a5a3048baba3eba418febf47d143
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1_arm64.deb
-    digest: e545d436bd07777713063cbbafcb75c2e2581d2f04ec697862380caf2074c471
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_arm64.deb
+    digest: 0b59eeb273489ae76f00c5192fac7d4fd7ca4db31b0f77b1424cbe6a70fa20f8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libelf1_0.191-1deepin2_arm64.deb
     digest: a3926debe22263846a70333372425e555a2ed796d44b8fe87eecd8116dedaf2c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libencode-locale-perl/libencode-locale-perl_1.05-1.1_all.deb
-    digest: ef71d5b44ceef8015dbe954f6007f7d7fb32ceeafa49c8afc28ea8a79d4e9ad9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_arm64.deb
     digest: fbbe2a51d531e25bc6bd01b2a732ea480411f065940a2b581d47dcd98ec7fcc3
@@ -694,11 +679,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libexif/libexif12_0.6.23-1_arm64.deb
     digest: 0286b248296c6e66e209cb3f9b365e8133ede3911089ee68d8030a2a5212a8a9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.5.0-2_arm64.deb
-    digest: 06c39c3e78aba8616d2c7b43d7cc33cd60bcbfb7bc362e997b2bce1b24fd7460
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.7.1-1_arm64.deb
+    digest: c0b33ae628f9f7a2be567fc237b7c3f3c2ca1ef33360eff1718977c72d414a38
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.5.0-2_arm64.deb
-    digest: 2c66c6eb5bb8e1f8dbb6449e3948e3a75add01415561c10a89ac1b238a9a24b1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.7.1-1_arm64.deb
+    digest: 5cb7b15a898bfb29141bc121435c82871d5ac497035fae132c37df32e69eb388
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libext2fs2_1.47.0-2deepin1_arm64.deb
     digest: e8929ce0ede640e5ef66a7d194161fc4e7f256c97e17a77e31bf12421810dd7d
@@ -715,17 +700,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_arm64.deb
     digest: 5417b1bd3affb161bac0dcfd46df7ff9f431030d084a23652b9f04ef51a8ccf4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-basedir-perl/libfile-basedir-perl_0.09-1_all.deb
-    digest: 79f5ef747c15be92e24a1adeea98e3d4c01b1b90b730a184a8ca4959a1aa4684
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-desktopentry-perl/libfile-desktopentry-perl_0.22-2_all.deb
-    digest: 19ed7f791a824bd6525c02cc6011bbd614880f3408e78eff5e16e1e9990334a8
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-mimeinfo-perl/libfile-mimeinfo-perl_0.30-1_all.deb
-    digest: 4d9cecdc4b82cee837e74512293b8c84a554d3cdf6c760627cd9c42d6c752b92
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/flac/libflac8_1.3.3-2_arm64.deb
     digest: 8a6209363d55641f2e981b054bf9ade88af6c0de9b966107de96d1f6a1a792dd
@@ -760,8 +736,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fuse/libfuse2_2.9.9.1-1_arm64.deb
     digest: f2a71c8caf7e61e0fd26bf34dc1aae291bee5d0ac9bc22050166a7eda40c4132
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin1_arm64.deb
-    digest: 0e6e5eb75926984f164fc7cab721af768f3e39a02e0fef08a80ca511e0932216
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_arm64.deb
+    digest: d16ede274574a5ede58f7f2318cf33f2b0074ca31845097ce633393b87b3caf0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_arm64.deb
     digest: 6ed2090f5c442f6dbccfc825cf0303e42954ee2db527d4605435c09862a43d57
@@ -808,23 +784,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgfortran5_13.2.0-3deepin4_arm64.deb
     digest: 3dd3c892014a1d9e170add45761bff2db8315d225da55ef0abbdbedf9fb95232
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gio-qt/libgio-qt_0.0.14_arm64.deb
-    digest: 95fa3e99b2ac7dfda5969ae4e355ff15b0e066b2f9b81d4b7e98d68002c8fa87
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_arm64.deb
     digest: 67fb7f1a7f5bf707a6dcead0b5b044c1704f454c2a51050fcb020ea9b1317913
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1_arm64.deb
-    digest: dc7f67af872323ece8087a4dfdd6106b9faa71d490447003ef964043066bb2e1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_arm64.deb
+    digest: ef605bf23fa580844d6a5faa61caf503f3825bc69acc9e30dab40689116a2627
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin1_arm64.deb
-    digest: bd784febc8b5b98a79ba8e2bd965a894cc684d01be1c1252e2d8af5996690a34
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_arm64.deb
+    digest: 9a47b3a7b9568d735534ae7c949ef5bed2ff18975f0812d71acbd163c6f5030c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1_arm64.deb
-    digest: 93917761c2f8cdc9dfec793a9e6aaedd05973aca3a19eb74f2d33e926c0d7c3e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_arm64.deb
+    digest: fb58114fedbd3864291f2a6c3d7d5d1b62476a3532e98926774727988411b3e4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin1_arm64.deb
-    digest: f5e97f18d419e19676b353c6c7b50fd07581e009ead603ce1b7129ba71a1e964
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_arm64.deb
+    digest: 82508b674b91518c3217f0d2f38ee78ed65a15fb6acb49420076d368e338af7e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_arm64.deb
     digest: bcd728365b170a9b2598f2c3a13a7b4b27bcbcc5c966610496f7a66c13d93394
@@ -844,17 +817,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibmm2.4/libglibmm-2.4-1v5_2.66.6-1deepin1+rb1_arm64.deb
     digest: d09d972120030491fcb077ba0f03c60c95802a1e14fb3d1026a4cc82f99d2f8c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1_arm64.deb
-    digest: 3eaae06ffb183872a95c2c966050099ab9824b50ccab6802c1fdc95a7f6b25d5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_arm64.deb
+    digest: d4371fcc299ddafc3230a139ecc4475dcd0b0dedb2746d46da1de9a951bf749a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1_arm64.deb
-    digest: ef37a90a94a9e4ba16352663b2703df57e3816e406eec0225e6339a91ad498fa
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_arm64.deb
+    digest: ff60370ae98f4515ea9eda99af3ab9d468b53b23bdd22f4b51abf8064655e810
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin1_arm64.deb
-    digest: 3dc940cbcf83fdae9499703bf42824b87be132d5130643c4845788ec878e923a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_arm64.deb
+    digest: 9388fddc0b068998f436342e6d562cc6f5553f34dbee9e86a51639a24d92dbaa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1_arm64.deb
-    digest: 41d194b986ca2e07171948e6b0d09b2b51f068117ae2f0bd11105e0c7cae8d7f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_arm64.deb
+    digest: 0e206a1e5b7a0a16abefac96b5774e2740c0446d988488ba3ca3af616a4eb3f6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_arm64.deb
     digest: 6be533a6b6cb8b661664fedbe661b316edd0bee46f51fe598d300c2efaf95728
@@ -895,14 +868,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_arm64.deb
     digest: bf8f6e987ba71ddd6161066f0828663b4ffc4af78acbdbff04b71e5c2b1e207f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-qt/libgsettings-qt1_1.0.0-2deepin1_arm64.deb
-    digest: 418114289f248c33a0200dbc60769b2b9c040f47d8bf0ade4c998db0969a37df
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgsm/libgsm1_1.0.18-2_arm64.deb
     digest: 433078cb4127d8b89dbeaec5ba11ada27bb88ffb3e6a23bbfb882fe6e6a253f8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_arm64.deb
     digest: e09ffd8646be9798699b1324b7d6292382f7c8c3665fbd0a6aed4536561ff06c
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.6-1_arm64.deb
+    digest: 06b977fe892b4b345194c8200eacaa8ad191c3b61795b10ec1ae3488e7b2d923
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-0_1.24.6-1_arm64.deb
+    digest: fe676a9a2a00a62843939e1bac2357de88580ea0071c2505a414f1cadf7bad31
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gstreamer1.0/libgstreamer1.0-0_1.24.6-1_arm64.deb
+    digest: 03dc57072d4dba09e76c53b9cba3371a1aad5dd660b8e2ece12ecf376904851b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/libgtest-dev_1.12.1-0.2_arm64.deb
     digest: 1782a1ae89d81c14a53cdc7be83811cf3448ffe2f93a475820ff96042b5bb4c8
@@ -915,6 +894,18 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_arm64.deb
     digest: b50ec89e04006c13764afac632d9fd4793c187d20fc54670018f76241fbe8495
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif-plugin-aomdec_1.18.1-1deepin0_arm64.deb
+    digest: c2b72a9c15f9e8af99c3b24255732179e4a98d3a50b995d3ef4e2cb2ff61f245
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif-plugin-dav1d_1.18.1-1deepin0_arm64.deb
+    digest: e62c458f9a7fd60bae178b8387c7fc4610a59c23a95c2715b0a42f3cf5732abf
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif-plugin-libde265_1.18.1-1deepin0_arm64.deb
+    digest: ccf7f3acbcf1edb65d19ef98159421f1d87ee56048bdc7c7253812d62856e3b6
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif1_1.18.1-1deepin0_arm64.deb
+    digest: 068ea1e11c4877204aab8777f4909276aba3bb09cfd1813c358853ff29f85700
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libhogweed6_3.7.3-1_arm64.deb
     digest: 0caf1aec7651bca8c8c0646eb87b064e522fbdc654edebc8c7e10e0a12f77c94
@@ -942,9 +933,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_arm64.deb
     digest: 9a6aaef5f1bd4c34230d194a5d13354b0e614fe330d77bee0c293b9a627ca752
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libipc-system-simple-perl/libipc-system-simple-perl_1.30-1_all.deb
-    digest: a528ecfa70fd8f3b4cc024947ff264e3952b0245be9a7147e556d8e1a037007c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libisoburn/libisoburn-dev_1.5.4-2_arm64.deb
     digest: 7c6acc76e107767a34134fc4e5c0690142459dd7cd40df298dd882f68213b357
@@ -1000,12 +988,6 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_arm64.deb
     digest: 91223dc8480403e5770986e2fd73b8a92ce1e74b9f52b442616cc3ef0ff59dc7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kcodecs/libkf5codecs-data_5.115.0-2_all.deb
-    digest: ea3e2873fa4d0e0fe356c8de8a93d0dba6dcb38ac53f215a4bce4cda28d63fe9
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kcodecs/libkf5codecs5_5.115.0-2_arm64.deb
-    digest: 1fe82531f63e00e381b022cbf6321aacde3db60b2edc92635d2bd1334b5f47a0
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kmod/libkmod2_30+20230601-2.1_arm64.deb
     digest: e2a560f5d202d9c49f7f823373f5d54db3ccb5d1b155ef5eb2b0db8e49ff974f
   - kind: file
@@ -1057,11 +1039,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lua5.2/liblua5.2-0_5.2.4-1.1-deepin1_arm64.deb
     digest: 176eebbd799638be0e3978bf1b0dd9eae03246740538b661d3209be9ed5b721d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++-contrib0v5_3.0.8-deepin1+rb2_arm64.deb
-    digest: 0876e26acaf269a20e23c63b881b13d64ccae4c52ce2a7d5d62d2cf811b57c88
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++-contrib0v5_3.0.8-deepin2_arm64.deb
+    digest: 4781dd6a418a50aae001e03be940b08372fa3f775b7142f8f1e23ec9dedbb71f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++0v5_3.0.8-deepin1+rb2_arm64.deb
-    digest: a5677ee893510c8527242ad6984b1f64bcc2ff86811b7b1068c5fd25641d0a38
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++0v5_3.0.8-deepin2_arm64.deb
+    digest: 8204767368063a541d995efec093e6a47e9964f89919291dfab31b9cda468101
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lz4/liblz4-1_1.9.3-deepin_arm64.deb
     digest: 9de94343c0eaf87ec1b298d8f5dbfe42f06316f8dc608968e0718437035c1ee9
@@ -1110,9 +1092,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_arm64.deb
     digest: 54405180731f47ec74f3cad85575beb66fa5d8f2bafc20e414f90d1515dd0ba8
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtmpris/libmpris-qt5-1_1.0.6.1-1deepin1_arm64.deb
-    digest: 359f7873adfac1c0e9953d8f65a75da34b8125df8bce497d55442a6b50744336
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mpv/libmpv2_0.38.0-1deepin1_arm64.deb
     digest: 8c1e50c994350e741c85cb5aafb7337377204d10f2c8fd3ca875497b77ad483e
@@ -1192,11 +1171,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openal-soft/libopenal1_1.19.1-2_arm64.deb
     digest: f08db4bd3d80d68cfdc9a22608bd40f166fdc42636b75836bdb4f0fa3e77f546
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_arm64.deb
-    digest: 4183274244acfc897705999133091b52af3c9c1ec54ed4b67319e9b044281434
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_arm64.deb
+    digest: d52a6102a07d9cff9066f0e3ebd802ab14e119bd1f9a890999be8cfda4c2cdce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1_arm64.deb
-    digest: 84392d66b03e40078cb2fc079e1a3b8bdcc5d6606e24e9846b552ee73e2ffb03
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_arm64.deb
+    digest: 74251d10b4940be8c9fe26be6c337af904a1f0494723882d50dd1bcb04189416
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_arm64.deb
     digest: a7dd240a390ebad6e63a7b7ce985a54e2e3753d025f5a040c6c28727e6741461
@@ -1206,6 +1185,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/opus/libopus0_1.3.1-3_arm64.deb
     digest: c46fdbd130a878dff3b384ef37d302f4c7c72da43b05eb91e07fb62cf9928a6b
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/orc/liborc-0.4-0_0.4.32-2_arm64.deb
+    digest: da30ea2308df2e7f60064c38ca2fb159bf613b7eab446184668b799bb917777c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_arm64.deb
     digest: a8cf0f0f9be1f016846baa4b2d2012fbef8b560dfc3cfa920b3d8ebb920038a4
@@ -1219,8 +1201,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pam/libpam-runtime_1.5.3-7_all.deb
     digest: 28a2789917401d06fff5c31991bf27fc808626c5c086219df63cfe1acf978b97
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libpam-systemd_255.2-4deepin6_arm64.deb
-    digest: f24cd998da4c3c33971dea4d55295dfa227d698ee05f117d241acf4374b91be7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libpam-systemd_255.2-4deepin11_arm64.deb
+    digest: 3032d1e91d9c7d7f4f2a251c93699df1874fc8da555338eacba3cbac508ccced
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pam/libpam0g_1.5.3-7_arm64.deb
     digest: 80c8d2cb574ad570bd4f32ec1b0782d12c60bc77a176cb81574e45b341c249fc
@@ -1252,17 +1234,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-posix3_10.39-2_arm64.deb
     digest: 6bb5a3b25014a1b3d0daff71338861f704defc4a1d7d5a2896b58604716914f3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre3/libpcre3_8.39-13deepin0_arm64.deb
-    digest: 4c97742578bdf73cbe239ca5a1a878b656583841ee388b2a4b9139dcf9508e11
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_arm64.deb
     digest: 0845846b66b31eedd72c968130416fd011806d63c87506237ef08fa765edfc28
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_arm64.deb
     digest: f09601fbb60184cf2257b12a7eec5e39ae0d8659ae517bb42de686abc791f5a4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin10_arm64.deb
-    digest: 8c5840595cd53c664c6439dfb45bb57f3d181c60d5825c305835909b0ed3eb19
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin15_arm64.deb
+    digest: d5f136292ca1de46965ae6493560fdc2dc6d0360650f5ae68db5d54e547f87d7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pixman/libpixman-1-0_0.42.2-1_arm64.deb
     digest: 7195e91186e69bd55b9c05269973f6351a3a09470ce297610cf3d22ef6cac45e
@@ -1285,14 +1264,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_arm64.deb
     digest: 9523527a9becdf223c0c367aaaa04cb9db76cac405316314ee5216f991384fb5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin6_arm64.deb
-    digest: 145c1faeb428c003d1c00e22c25b4ed3610f3e51b26859d144f2e4590ca935d3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_arm64.deb
+    digest: b97403d9f18a9f81f3b2f39f8d7bf458e6667f228759ab104824be390dc7c291
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin6_arm64.deb
-    digest: 4cad261fc851c6e8d4c4f56fcf3c7845c9c5cb628580b8d720166dd4cd0cde86
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_arm64.deb
+    digest: 925c8a5c655f77618d9b764053fc51eaf5cb61dbf499c2655be89e2da21654c4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt5-1-1_0.200.0-4deepin1_arm64.deb
-    digest: 82abf807bd749f8366d50e77168da7c99a7712fe6f6441371840767e8377a89c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt6-1-1_0.200.0-4deepin2_arm64.deb
+    digest: 510509608df1e38739722d377529634263a0bf4c3c265bd6874dc89ab6bea2e5
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/poppler/libpoppler-cpp0v5_22.12.0-2_arm64.deb
     digest: da9785af8ac3375c2098da9aab07c1b6488eb29be71f87117cb5b032f06ba3be
@@ -1303,11 +1282,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/popt/libpopt0_1.18-3_arm64.deb
     digest: 17a7cf13b9c83ff20f5e8f099198ccb74e100c07e1e817fa7c4e1faec2dad159
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin0_arm64.deb
-    digest: fd4cfe4e776eb26907c33a896dca9daf8e0c82ac834bd7e662605d1d8df6a86a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin2_arm64.deb
+    digest: 55e73753b0ae18a65a7aa9c126f52524a93888f7cd2b8fe1503a9cbc140cfb51
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_arm64.deb
-    digest: 641e0a94a253612ff4e7be672d7ee28f5a9c98e263a5f065d9e4cf47dfe00681
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_arm64.deb
+    digest: c4961acabed64ea88a254ba89930110925ea89fb182f5d088e428503d9c531fe
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_arm64.deb
     digest: 906e8192d44527cb25bcbfd2a90992b25acfc3698a6b0cc6536edc6e935d64e6
@@ -1324,68 +1303,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_arm64.deb
     digest: 94be53c10a1ed8538483d1dbd426700ff5a79ffffc7632c3a3eee0cd9ba2e869
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_arm64.deb
-    digest: b7e82676b670321d2d402bf6cfd9f8b031d1e25711409981609d86c11ce66395
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_arm64.deb
+    digest: 6dc58f5d2bda46ed44cadb9a08729430975a9a4dc41eb28f6633c6be041f9085
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_arm64.deb
-    digest: 7aa6784e459332f64d348c4d2e8d2f78ce167651d2be6361bd4e993c0923aac4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_arm64.deb
+    digest: 73b9c0dcd766f4132d7aaff51f969d0ed8708f54355143d308aaa7033018d198
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5concurrent5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: d2916073cd1dc63ab22454d8db1d944d9b7b3f4dd18550c5789371fb36074edd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 3ed642827043b354e44832524287cc3808804c996e5c9fcd18a3ed7b051f435c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 3cf53c5a9172bc03c318cbfeb04a27c3a18864d36640fcb3f3bdb0067912f8bc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b2ec9e16dd93f9fcc6db6a8213ada4c6a032263dc26ebaeaa518e1020587e33c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5dbus5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 4d1bc048a85e2f1da4a560a90e6414c2462325f7a52a35c3da1e3c4a6079b376
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5gui5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: b6c7cf8460dd602ecbed114ca0e65fdec06530a8225b60102c5912352835f31b
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtmultimedia-opensource-src/libqt5multimedia5_5.15.8-1+dde_arm64.deb
-    digest: 1b970be67a6b04870243da10401ae943c8f13c237c8b7543622b7cc4423bc598
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5network5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 450a311182923d757261fd29988b6a31884c982d3a49c21f701cfc5818fb7cfa
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5printsupport5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 113206ec23e39aa202e9afcf8cfa2795c65d12de7243e7f0eb8d277f6be05cbb
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5sql5-sqlite_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 3c69fd6edd17443743d72bea4930bd8b6952cb7d675d28e88aa722ec5649f273
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5sql5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 968d94b5156b9bd1fe6d5a1cbb10814cc4910492836845aab00da970c0efb8e5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtsvg-opensource-src/libqt5svg5_5.15.8-1+dde_arm64.deb
-    digest: 6c64ab3a22cbc443bd2958f5e669c627dfede242695828b97050784048fb921c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtwayland-opensource-src/libqt5waylandclient5_5.15.8-1+dde_arm64.deb
-    digest: f4f75455d300810004ac0d6e2f6343206a95cfe51dfbad87c3a09a88d5163685
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5widgets5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: a79351641eb886cb98d75f566b9f8b033c1d33f9d2d82626b6bbb5193c41175c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtx11extras-opensource-src/libqt5x11extras5_5.15.8-1+dde_arm64.deb
-    digest: 133c025998e17803284b8f8f2b1f8ca02671396e8b3c9f66d5759ee3fcae7f38
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libq/libqtxdg/libqt5xdg3_3.12.0-1deepin1+rb1_arm64.deb
-    digest: 4cbc3076c9897a4d44363e284d4ab3e56de00ff634637610fc72041cbe264214
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libq/libqtxdg/libqt5xdgiconloader3_3.12.0-1deepin1+rb1_arm64.deb
-    digest: e91024905a202dcd4306120eddee95dc16dab34e8b3bb4220c6207322c46e170
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5xml5_5.15.8-1+deepin9+rb1_arm64.deb
-    digest: 90507a5f456438e1b79ba5d0db687abaa29727102aa46c7fe3397d378962a565
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 4487ef000bab280d24e5796107f266dbcc7bd98da9107fa46622ec2466c7b16e
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 8e79cc85474e16b11086c3943e9f68ba2980cd02c25126441d5787a9cac9f126
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 7b23577876590b68e561e40905d17bdd102d05ec005bd3f3aa02085435f729c5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: f23850190fc6dcfcb2e9552ad18a861690f1c9d3a5b2ea8d7c1726ccb3d7ccd0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_arm64.deb
     digest: 82c28b84f82cbf7e3d9098c0f856b955e811a65b1fd42c8515711aecd05fb894
@@ -1393,23 +1324,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_arm64.deb
     digest: c183e82838d5b340b4273253e90667078512862e1f8e9781b72b7ce048bf54d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: fbc7604f9d54ffef67fac1b67eed229d14ca15d06a45984e316768b7c63bd930
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 865f2bc49642dca8ed4b823a6cd6e286e0e38922b94b333b3d1c6a135b068a0a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_arm64.deb
     digest: d725d7423abfc45ea48abf3d9cc444b95af145636802254bb44565f31d4d4245
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 34ef8390fb279d048e66d691572247d54ea7e04222db0507c44ac113914c0cd8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_arm64.deb
+    digest: 4f28fb916cd81a9d1275944c7d7b1215c67c9f11782559c49d289af2c9034d2f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 2280d74bd82b5e9d3a065c9acaeedc7d9f3c222517588c7777a62de2b30ff51a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b4adf25025b9ac22a52f68777b8b0e35acb2259b0c5dbb6d21d1e390bf272246
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: d79ad717b4275bb2dec400e7fa3ae8045c4d93b38fbc5a9c5eece9e9d7d3d14b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 14b464d8f9c3c54bb8adf97c276cb3862e37403897250d96dc3cd2918d2c4ce0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 0a2c121bca7a1b60607aed1855b50fd2c630622bbb2f4b9fe5362a4a187893eb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: abc3d24f963cab39c953bb44b1f1d258a0cb06716345f71bebf7bb70deee3f17
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: ded05e7b5416ee5139309098046f51d68eeea2f646c234113f0c4b754e7c362b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 8c18da39ba69ceef945d4c64e3a0e62a1bdcbe2b41921ead0aa08f4cc52c459e
@@ -1429,11 +1363,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 9e46187cdd05eae2b1113623f827e080aa663da7919c1d87b44dbb03792b4dbf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 1f084ff72c612db83096eb3dec73f6101af9fe977f3376badf680a07926ccaef
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: f7b98e59524a570d02433e2773cbac7cb14f1c2862bd5252b9decd75e8921489
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: b8b4da1591cec015ace3dd8953ccca06f19f3430ddfc39faadcc6a65eda21965
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b9e0a5ee05c9c86e240c655e6e78b96ac25ab93b082f9ab04139be82dbe60327
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_arm64.deb
     digest: 9902fd043a3e62bba9f7d13edccd49a25d8d17ffa0ec5cdc761dd7a5c0d8b63a
@@ -1441,8 +1375,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_arm64.deb
     digest: 34f386ccca09b000fd6621ede73daa2fac0b94f8fd9af514767a94ed39a15bf7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: a69495c011e5db7fd0552ffbe180cfb43640c35271ffe21be3bcf44053ff72b8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 2ac2f2f94233663607c1664831330558c716de3f588ad4658b82f45085d5bd7b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_arm64.deb
     digest: 75ef6edab7f429e473a3f73bed21049eaa774f3e6333cc583e55b1f6bda9f016
@@ -1450,11 +1384,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_arm64.deb
     digest: f4b2cfd1d6b0a4573939eee7d9a48133e1068fb741d0b4ec8dc18889bc24fb8a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 3f27c16a00798b99ae45f723331d3601e3c3741e6041a0ea4bbaec0ee7873c16
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 3b09263af197ed4bb2ca92e54db9b7e14e141d78de8f143a578e01bf707f4094
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: e1cdb4a74a5f30c6580796070a19e575e0f6c5f9467c5f1c9561bb113cf66d78
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 5336d29dac452ff7e4f227f421dcb52bb6278488d4ed2833663d109e85126f49
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_arm64.deb
     digest: d38dc8bd34b4cf0fe94e16797f662191b91eb9e16f9f0b44bbaaa9b4b4d736f4
@@ -1489,8 +1423,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_arm64.deb
     digest: ff33028cb84a0712ccf76443ab69e9b52dfeeb33e2aa20a98c2f4a0a6ed97a4f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.30.11+dfsg-1_arm64.deb
-    digest: f6add35d991b2a757f20c96981b9f6880b6665b609a58ae274ca7af030908d63
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.32.4+dfsg-1_arm64.deb
+    digest: 6bb46338c8142ca9a18905b3f688b85aa34fb2e193f66bc4b17f5bbb4d10054e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libseccomp/libseccomp2_2.5.4-2deepin1+rb1_arm64.deb
     digest: 26e1bb15a35a3b4f948bd5f869c09bad65620a0898edda93b2639b7e3cdcfd3c
@@ -1576,11 +1510,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_arm64.deb
     digest: ac1056d07a450cced3125de43a15682b7cdc7060781697be7349235eb4e18093
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-0_3.4.3-1_arm64.deb
-    digest: 63d38bb5bae8c88b4b15f0696363c264c56fd409931268b8815f25c40793a928
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-0_3.6.5-1_arm64.deb
+    digest: 14f4d1975d8e9c4c72d8f917aecdca4f0c197c2865b3d83ff950b69f3d5aaef5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-common_3.4.3-1_all.deb
-    digest: 1591543d840396ea47f24a2b3287dabc0a50eeb085e07f0807cd99a4ca992f13
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-common_3.6.5-1_all.deb
+    digest: 1ea79c817fec9cdbea2a333656efe9898ed4a7492018321c6b8a1a12a013ae35
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup2.4/libsoup2.4-1_2.74.2-3_arm64.deb
     digest: f55f3a318e6ccdc1039fcf0469f39bf4ef61c711bf1ab9001f17c37306c5ec0e
@@ -1591,8 +1525,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_arm64.deb
     digest: 57472a0be9bd78ef65aa7f486c6b1236c956798c2af1152d7fd71bcc71d73bd4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin10_arm64.deb
-    digest: 6fd9b67263e80bb6785c55e36bc33cf204233450ff6d542ca56106ed4411c334
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin15_arm64.deb
+    digest: 77604d5bb598b39c05f8f400493e017026ac0e66ec7525a302ab14e79b35ccfd
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_arm64.deb
     digest: ffeba610e1f0ffa299499d88562b65eece4f9865d8810d3a6194ff5d2cd02b38
@@ -1615,11 +1549,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_arm64.deb
     digest: 830239bef63460fabeb07413177ff1377da7b67edb62fb4710ee06c764f232c0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.10.0-2_arm64.deb
-    digest: 8773461c957ad9b7540a9bd89a54fdbff2bced08c3397b2e00b4d5629e4985cb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_arm64.deb
+    digest: 08093eb78fa9240413e29c306f3af7f2ce9cd2599d0905cbbc48166518849895
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin1_arm64.deb
-    digest: 91551d3d67e2ad04bc982b19c3c9b69da43bbd1ce0cceacbc98a3bbfe6e268e0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin2_arm64.deb
+    digest: 52f865e7d1f3a927ba35308dd28a7aa3856dbda643b4976595519e652c7bf850
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_arm64.deb
     digest: 6afa3a2ae947564d05b220d89298c7e6e1f875cb05b4ed1a9a450be99a3ba47d
@@ -1630,20 +1564,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_arm64.deb
     digest: cc104e0d2a339b388906430c5ddde52273cf42871c3d5a1c488732d17647e782
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin0_arm64.deb
-    digest: 644fe45e5ec69ae506a241ecc35405367e96fc96a6415600303b5fa1cd21e36b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin2_arm64.deb
+    digest: 74bdd2a07078ea6a0934bfc4bbdd5a6a722f5c808f0b397bc87430ce4b822da1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin0_arm64.deb
-    digest: 6ecc0d9b8a6bff03f7217a159c6642bd09481fc1cb164faaeb1c6f6995a1a3c7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin2_arm64.deb
+    digest: 60b250c05f6bbc0a570f2b484a50b2599b90e73a3616acc0fdaf9cd0d4958d40
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
     digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd-shared_255.2-4deepin6_arm64.deb
-    digest: db5e2c18a99690e06e31246cc7217810c387ce2aae7efd617f3ae80e4a78a959
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd-shared_255.2-4deepin11_arm64.deb
+    digest: 483240e95a5b81a35c67c033203e26eb5a15bbcba0dab18a76634f31dd8daa8a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin6_arm64.deb
-    digest: 1142621c30d6b43d1b0cb2d8dc020424ac3d52f7eae8f02b1d1e28a539cda2e2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_arm64.deb
+    digest: 694573210aea6173c54cc5084a8c29aa2001200e0a1e2144d6338463050f3979
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_arm64.deb
     digest: 287d31cf9321b19b5c7d104e8e1be43c0e6c4536cd64eab2b6c9813ebe1772b5
@@ -1702,32 +1636,68 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tslib/libts0_1.22-1+rb3_arm64.deb
     digest: 790a0e469c3b174d03eb0eb64f4a69ddddd95ddfd4b8daf930e4b4ac7cde179b
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-mu0_4.0.1-3deepin1_arm64.deb
+    digest: 63c82ff13b6508815102e78c2b5f5fec1aa5124ba83c4d47a5d82f880ab79742
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-rc0_4.0.1-3deepin1_arm64.deb
+    digest: 1cfb976ef394685ba0a5492bedc18183654d2ae83fe7f7c6e5d548c6a41edf4e
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-sys1_4.0.1-3deepin1_arm64.deb
+    digest: 740cecd2c47d3cd217b61d621369ca33c38eef72323ed0c1761d6ab062eab431
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-cmd0_4.0.1-3deepin1_arm64.deb
+    digest: e761d3ecb1cb05db10f73653fa97004ac840a2cdbee425da54cca246a32d6b46
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-device0_4.0.1-3deepin1_arm64.deb
+    digest: bf8c85db75af9339224402937a6e08d1d2cad51672dd8985edb78e5bc12f3c15
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-libtpms0_4.0.1-3deepin1_arm64.deb
+    digest: a5c7519a172163b456cd514252a737b77779d61144f174a13216c1a2ee71aed4
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-mssim0_4.0.1-3deepin1_arm64.deb
+    digest: 1cf754870dcfc41288108ba02eb361691f10fdb108b3a890e552bbbe3e0156ee
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-pcap0_4.0.1-3deepin1_arm64.deb
+    digest: c0728c2e0563765935ee76edc4234696185b3df9dc7022761850bf80b04dbffa
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-spi-helper0_4.0.1-3deepin1_arm64.deb
+    digest: 7b2db9a23af1acc89ecdda7ea91780e4cf51512404d2ec0180400038f1f29c7c
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-swtpm0_4.0.1-3deepin1_arm64.deb
+    digest: 460a258ecd76c37c090a6842dee8608aae3fa7338d01b470f4c42568c461bcea
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/libtss2-tcti-tabrmd0_3.0.0-1.1deepin1_arm64.deb
+    digest: 29d5dd1590088da74772c06e33944423bcf3f0bb4fb024314ee1e06945516499
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tctildr0_4.0.1-3deepin1_arm64.deb
+    digest: c1dd1676b5cd10be30014d723fc6f913a8474db2274ca45962f04faf77f15b53
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/twolame/libtwolame0_0.4.0-2_arm64.deb
     digest: a247a9281bd98fc91f1a6ad3df03546b2e98885a02a72c8d827ea77558ea3c83
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_arm64.deb
     digest: 08e6350a1fa2f96b99505d8421a1df75df69e8eef71e8d59b30eb0e778b8b4f9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin6_arm64.deb
-    digest: 1398b2595873521002eea280487c1bcce4a1c7463548f0af5d07f7dcbe8f14b6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin11_arm64.deb
+    digest: a6e7866b11d30f3c747d2b1a9cac9c4e9c8c233ff4c546946d75345fc3352aff
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libudfread/libudfread0_1.1.2-1_arm64.deb
     digest: 4e25fbdfe08288e6f58cbf5a02a5147f4c2d6f41927020d20cc1a60ce49b5c0c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin7_arm64.deb
-    digest: 96aefdb686dfdbe7d62b948027fffd7b67a306ecd2e39730305b68df42059571
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin10_arm64.deb
+    digest: 64227cc0428eba7a95ceb96941b1d152002ab0990ea733c14a2911deb2bba587
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin7_arm64.deb
-    digest: 4fd7b4a8341418ca3c70c25f8b238c32c23eed2ae947b363e802520f8424b24f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin10_arm64.deb
+    digest: e388219b67c2fd9b42a1129d33c6fc2304986229709accb2e26d40e9c51cde71
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2-qt5/libudisks2-qt5-0_5.0.6-1deepin_arm64.deb
-    digest: 99470e8b7b315bdfeb371dd37500350d2181dcb9fbdfa0c6b70beddc764cbc08
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2-qt6/libudisks2-qt6_6.0.0_arm64.deb
+    digest: a04fd4d19191ec1fcae6936d9288ff1b455b7186be6a609ed034381fcb1c36fa
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libunistring/libunistring2_0.9.10-6_arm64.deb
     digest: 55c2f09476f2f0e2949afdab39939e5cb62cd99976bf36ee189011e34553b06f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/liburi-perl/liburi-perl_5.10-1_all.deb
-    digest: 485904ff807b96c4d1d18d248a40b01915d37274df732235119ecd2af01f872f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libunwind/libunwind8_1.7.2-0deepin2_arm64.deb
+    digest: 64d485461e0f091c1b8cb772bac0c551dc3a1a1543ea21bccd4d64bb0948cfae
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.24-3_arm64.deb
     digest: cbd80aa62a0b636ddb7b12bf41c9880a938e8a80f822ec1c41b2c2a45744a5b3
@@ -1843,6 +1813,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau6_1.0.9-1_arm64.deb
     digest: 82a1fcfe359eeb57e4c0dedd434719360650ed2423d08af807a06d0a0ba91bae
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xavs2/libxavs2-13_1.4.1-1+dde_arm64.deb
+    digest: 16865284f307e4c2a2fe25a00dd50b4a6d32d8079f9615f30a913f41aec36e37
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_arm64.deb
     digest: 3e5079ca95b7a9f560cd332344e808d35a4cc1d90b57737abd43c8807fd9cd93
   - kind: file
@@ -1887,12 +1860,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_arm64.deb
     digest: c3c442fc82728a145e47ff2ce37bf173cc96bd26dc3329f8eed3daec2d47c211
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xinerama0_1.15-1_arm64.deb
-    digest: bbc6e81ea9cadae29200ea4b3072c4778209bc04b9f46244c42c19574fc139fb
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xinput0_1.15-1_arm64.deb
-    digest: 78982b10c6d3417c59de87de7554b1b5bb2e1f494b5a8d5e7d0dbe109ece7f57
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_arm64.deb
     digest: 0386603371b588c01d5d5114b96c0a05c62b9107ee8033807a9c14e8e466da98
@@ -1990,17 +1957,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_arm64.deb
     digest: 36724ed79e7cc83e5357ab2f3e8c2ca75362b5352611bf5bc3c54289191f3e02
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.35-18_all.deb
-    digest: 1fc738c696936a298eab3f5a6061ae0189078abddbdf7ef3da2b39537d47aa85
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.43-2deepin1_all.deb
+    digest: 8c4f70100c1fcb2755b08644f2326f0c42cf037e89c22cb69e4d0dd0798cae8f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.35-18_arm64.deb
-    digest: ca07a0b3834361af09936a24dfd36d16a41a3db8199cd41f666d979de8da902a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.43-2deepin1_arm64.deb
+    digest: accd5ecbd68485a1e997c1cf0a234f32aa21c87f39053af484c5e18a8211040a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_arm64.deb
     digest: 467675c0f4007bad669a8fefe0ec4ab45f1d356f947afd7aabba2f17b88401fb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.22_arm64.deb
-    digest: 6c428b10b15ae8850c7084eee2ba403b7f2ae6106d63fc4fc28de33593cdc626
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_arm64.deb
+    digest: 7a770cbb690f79ec2702611e320d3eced7565598bd3db72ac9eb060c476979a2
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shadow/login.defs_4.16.0-7deepin1_all.deb
     digest: abed558f44fdd893df5020fdd787b2ee1b5cbc8b5e4b78ab4b01b8f1cc1aad08
@@ -2020,8 +1987,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin1_arm64.deb
-    digest: 1ba8fd0166a175aadf6918c3b77560480c448988c97cd7f7955c0082da87f0d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_arm64.deb
+    digest: 60d8a9cf9d9fa0751184d40ff2771f8f832d3c27458af93be77c37f4e9c63b56
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
@@ -2031,6 +1998,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nilfs-tools/nilfs-tools_2.2.8-1_arm64.deb
+    digest: a85b6cb8ba4eef83d9b033f905284a15d1ca3e4a5ef43174ac2c251c1b50e84e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_arm64.deb
     digest: 2411c1cc39eb107516938b83b1eb50c29e9a6deb232723d65e17cbf592df8609
@@ -2074,11 +2044,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_arm64.deb
-    digest: 836c3af36831db46782bf20488cac27e14f2ce63e4d186c9cd8972593dc47056
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_arm64.deb
+    digest: f646ff8063d6635c9df51bf873deecfda699a61dc0db1f51745f770d4f9ae0bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.4-0deepin1_arm64.deb
-    digest: 0ce1f946a32af79b183fdb194c49a21742209a5c4b123608de8f39443f9a57ab
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_arm64.deb
+    digest: 0d85d36c0e59a7b1986cfa894814256a7361d2ccb5818e623712faa65795fc44
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_arm64.deb
     digest: 18b254c8a2ea4801a79cab3d7946d9730e41360e251094765cf8c4928f448a23
@@ -2086,11 +2056,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_arm64.deb
     digest: 2608678aef17e7c03c4b1fc3f3e8e10b91c7ec523471e4e4cd7790be50ef8a40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 01b961cefebb3c8c0f30ffd65c461f0000340eb4413763f621a42b41418eb905
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: ce44156c4871fe1af1cf1c7113d623489f7789b0cca8ae63a3acba72ff176889
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 3b73805c92b8937fddc76aeaae447efca88be5c4edb906dbe86185adc47da0fb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: cc0a67ca33b3c44efeb4723a95d34b986eb989278c17e9d9c6dcfa21aeef9b73
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 3f2442b73e48918050635d141f1ea8112442ff9217e92bd998bc9155ad201411
@@ -2107,14 +2077,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin3_arm64.deb
     digest: 2de57696a3fec69fb57e9b991484de49b4146c05b784cb7e6ffd50d9d7d913c7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtimageformats-opensource-src/qt5-image-formats-plugins_5.15.8-1+dde_arm64.deb
-    digest: 352b0e2dbe79d73fbb34bdc5fe9282781c8cab65e0136638a1398f36997ec3ea
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: 1789a73946e436fa2aaa758278d023c47ba8cc0cfe2547ac70c18f77058ba834
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: f1c60c7ab3ec69c9fd52a1d42fe8afdb1555e7e54bca71f417e48908b8868038
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 65ffeb095fc0fb17977dd797bb410d7a401f94e8dfb981813a3e6af39c54b7b2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: f86c153ce4628e34e8f59d66ecd3a001016cdc9cfa43e03756581a177be17e40
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_arm64.deb
     digest: 719086d3983481e4d78e4c7424a796831db3925c1ca6b3495513e9cde674565b
@@ -2125,8 +2092,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_arm64.deb
     digest: 9265848cc3a9da02d8de859a7705604e75d2baef2fc16cd243485e56f15ccf5a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_arm64.deb
-    digest: 87651591e1fd396c4af3a4073c2ae33690e34706110f882a05d984bdd895a2f4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_arm64.deb
+    digest: b5dc6687475a84e1aa544d8fa3cc1eb80c13ada54c0c3b10625fc96a605c6518
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_arm64.deb
     digest: e6732e7d1132d2a84254c8868b2c4cbf36e2afc4db8f82859bd8e5b9f40bbc7c
@@ -2158,17 +2125,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/socat/socat_1.8.0.0-4_arm64.deb
     digest: 26e2e524fe81773e9fd5d81b055462d8c41ac12559cd6c795befafdabd15d5c5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-dev_255.2-4deepin6_all.deb
-    digest: 41bec4491af5737e55f1c186ec8bd05d24611dfaeda7132354e75ccb6ea7dd68
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-dev_255.2-4deepin11_all.deb
+    digest: e6e0aef2dbe6f5df8626b630c52d8d63830e2979730b54839e7f84fbdbe34597
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-sysv_255.2-4deepin6_arm64.deb
-    digest: 9e85eb2e2e36dbf8d2d9e8ae1579288685ae0341695e0793f2b60238bea21f9c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-standalone-sysusers_255.2-4deepin11_arm64.deb
+    digest: 0cda98cb2fdba0787213a985fa5ae82e8d12ee86efb9c31ac1f1742b386ebf68
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd_255.2-4deepin6_arm64.deb
-    digest: 89325e6534bdcd10f9dfad94676fe40b335442c0838f2e2387a8ee50781bc926
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-sysv_255.2-4deepin11_arm64.deb
+    digest: 0d5b8a883bdfbab4e1a4126a1faef8d1e314f8a3be1e598fd97cb25055e14b7e
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd_255.2-4deepin11_arm64.deb
+    digest: 73794dedf1104bdec7d1c9e920ae766c21928eeb92736266cd2596bbbb296c96
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tar/tar_1.35+dfsg-3_arm64.deb
     digest: 9e736851d33ca49a6e7ae4b188c480ea0929cb8e322da77174570c64a1037175
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm-udev/tpm-udev_0.5_all.deb
+    digest: 8305c01b236dc4838bfd5f3331c403ed344207b35808d4bbb76dd58471a65b60
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/tpm2-abrmd_3.0.0-1.1deepin1_arm64.deb
+    digest: aab916abfd42e5c16796f91813e0fb31bd98e7928b6839a2ad245cf2ac75ac3b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
@@ -2176,11 +2152,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/ucf/ucf_3.0043_all.deb
     digest: 798643dc75a19ab6e0067fcd63a89c28f711c3e4769435e262dc36bba18f9a2a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/udev_255.2-4deepin6_arm64.deb
-    digest: c3ac0170c5d0dbac30342ed985bec90bcf496d17a658febea9ff13b668ee15c0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/udev_255.2-4deepin11_arm64.deb
+    digest: 23e06e070e6360c9835ceb2a491a66e08d0f42712fdd06bda0a1de27b8094a8f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin7_arm64.deb
-    digest: 2cdb96c3cbf83628892fbf6f8ba48d78fc776b03b803214947195c6f36193eff
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin10_arm64.deb
+    digest: 3814c541223fe1817a70a9064a21bc044363ba88c3be41f73b9f04ca57b4d16d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usr-is-merged_39+nmu2deepin1_all.deb
     digest: e8896ae20e16a3b4ab0ab4caaadf884de1c0056ff449f85ff1426415e8758a3c

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.21) unstable; urgency=medium
+
+  * chore: Update deb sources for linglong yaml
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 02 Jul 2025 16:21:01 +0800
+
 deepin-font-manager (6.5.20) unstable; urgency=medium
 
   * chore: Update package URLs and digests in linglong.yaml files

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     font manager for deepin os.
@@ -79,17 +79,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/bzip2_1.0.8-deepin1_amd64.deb
     digest: a67b553f354a824475090fcd7a1b6fe237598a1445158526027f2970aa976def
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-3.1_amd64.deb
-    digest: fe25e3ea5c363bb1235b3c52812647b06c7fdf94018a0f21dbc5b8c5817701e1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-3.1deepin2_amd64.deb
+    digest: 1737e5902f94d7c97a8a1a35762d11ffb9ea7e922126bb14c8cd999c8432b327
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1+rb1_amd64.deb
     digest: bb725bb6b5628391b35c88496a1f793a1b19220024631d0c2e7444206020ce44
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2_amd64.deb
-    digest: a82b85f523398f8f0c8773ae390bda2c3f13988f9e863bb26fd4fe5479f61492
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2.1_amd64.deb
+    digest: a3d66fbf7e609dc595c342063c2296e65fc6ca7b0832875827e91694f5c2d44b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2_amd64.deb
-    digest: be2813d9fc168ad51a3cf253186bf543df08020379fcd3bd24534d2f902a6321
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2.1_amd64.deb
+    digest: 9b73d9cfc9c3de4cf6c62607b916d93bf14052c80056554aa37b85c5fd3f6280
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dbus/dbus-bin_1.14.10-3_amd64.deb
     digest: 703c756370944c7e301d5c855350dd66b8df46bdae735399138afb9dc3fffa55
@@ -118,29 +118,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/dconf-service_0.40.0-2_amd64.deb
     digest: e0191ee7e4fac0aa946ee39591ccf6137ac7d9fa7251c7a7abc1740cea2146ff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_0.0.1.16_amd64.deb
-    digest: f60dc0a5a35636cb5a64b26954429a310d1064b3d7a94e562721638eb696e5dd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_1.5.5_amd64.deb
+    digest: 6fdb4a1523b47ee8db62c93786f7f1f58e24de681b9164765d045dc01f60a736
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-common-plugins_6.5.10.6_amd64.deb
-    digest: ef0cb97201bd4a402e43ba65b74d3407bd146c9b2934c95a91e43def0c21cc92
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.69_amd64.deb
+    digest: db64ea48a6024a5e2861b85bbcf1a1a8f25127377b5b15d01c639c3c2881613b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-daemon-plugins_6.5.10.6_amd64.deb
-    digest: 98c2470aa6751d30a6f742e16278d6b36f5ad6c0214e8feef0e1a51aec4d0e97
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.69_amd64.deb
+    digest: 5fc4737b548d24885569bc9bfb486dd1e1a16874bf156357ce8b1b448ef18e65
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.10.6_amd64.deb
-    digest: 7e44139df982f6e77a3915de78fb0e07908698273802e6ca60507851fb1adbe5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-plugins_6.5.10.6_amd64.deb
-    digest: b3e385782a9b3aef5a87229ef658ef664fe31a32de92ed211e63dbfc7e650221
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-preview_6.5.10.6_amd64.deb
-    digest: df0918f0290c007ce2449390fbb8112377e6386174ce1572fc803a13ec59d9ba
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.10.6_amd64.deb
-    digest: 7d57a57dd13ccbe2d11598bd2b980e562359b1adb6d3527ff0b91eb1e4fda900
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.10.6_amd64.deb
-    digest: 72a2d94b999bf78c9f66c896caec29bbe10dd403e1fe017e6b48dd4af3fe3f3a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.69_amd64.deb
+    digest: 07a12c3847fbd7b6a0728c2aec1bc972eca54b415416970f6be0508a492f4c9a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
@@ -163,14 +151,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/dmsetup_1.02.201-1_amd64.deb
     digest: 3e61ab2c0e4663d0bda4f98459055d3d3e8898c5893732d0d4d309dedbd63d11
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
-    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin3_amd64.deb
-    digest: f9c758ed0204b1fe515c70b6419f80fdeb4773ac3f498a79ea1e6a6e6971157f
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/file/file_5.45-2_amd64.deb
-    digest: 6c6f845118bedcf03b93d241416b6c4953a72c4ef17c76d7cbf42b67cfdec579
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_amd64.deb
+    digest: 2837fb44598aa57a0fc7d2b477c6539b3c268a1312f2580d4fb227e83d023d9b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_amd64.deb
     digest: ca239a17d79f439fc02525b3b3c83d6cdf0be1a90c6aa6ec6c19b2b92b0d6586
@@ -217,17 +202,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_amd64.deb
     digest: 101c6cc50091fefd708f98e3a9cbb3b8e6a6cb93d52bb45537c13ee0fa5e1678
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin7_amd64.deb
-    digest: bf28fb406d0adc929c38f75824cf1e029cb1e830c9367accb967b11a3bdc1b42
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin10_amd64.deb
+    digest: 42b5e9a5ffca17eed9ead1844ea6ad75c66e1d87d0f95030a150d35f24d9d993
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-common_2.78.0-1_all.deb
-    digest: 94bfaef9228159f8a2f366b9962e5bd82c9ddb53228b161d62c6f5d48ecf1c3c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-common_2.80.1-1_all.deb
+    digest: aa697ddbd07ba9e16391bd81f73661b2583859c8671d1ce92f28e6a870d37059
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-services_2.78.0-1_amd64.deb
-    digest: 1b12a72f80bd0a62d22b922ab3c8b90bdc11ac4bf819f955cccae09853755c21
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-services_2.80.1-1_amd64.deb
+    digest: ccc49ffdd19d4484de93198b0ff4849fb4f1989636d6441ce667340649cb4bff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking_2.78.0-1_amd64.deb
-    digest: 3becf1edd62d0fec815062fb84cf821dea5801f946e5191bab534e5d28f8d1d3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking_2.80.1-1_amd64.deb
+    digest: bf74722c6e023dce79c6bd181a74c5ce98d971c5b9261c10cc9a497146833f05
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg-l10n_2.4.5-2_all.deb
     digest: c9e04d548f5db44bf2772cac43a1fae57f0711e9ab939d0b8eaefa284f50df0f
@@ -268,8 +253,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gvfs/gvfs_1.54.2-2deepin1_amd64.deb
     digest: c3b464971b5a0737f8d2aed504a0c358df6a50634472eb0afb1bffac336cb0f2
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/hello/hello_2.10-2_amd64.deb
+    digest: 419bf263fc5c36903f07f03dfe62e5365163e52ebc1beb717867b5c7aeb47bf2
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
     digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/iso-codes/iso-codes_4.16.0-1_all.deb
+    digest: acd8d976f1a757da000d9ea9405fdf80194a6275fc93fc472e1df1dfa5b301a5
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/keyboxd_2.4.5-2_amd64.deb
     digest: 4c24beb848d7a567609da99bcca6f5c6969db44a143dea535b9d1b1a975e9c62
@@ -277,8 +268,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/abseil/libabsl20220623_20220623.1-3_amd64.deb
     digest: 23ce45fe62610dd94dd8df7f0237509622e65c12334ea84d21ceaefc901d195a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-1_amd64.deb
-    digest: f06e936eb913b8e9271c17e6d8b94d9e4f0aa558d7debdc324c9484908ee8dc8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-3_amd64.deb
+    digest: e7235d27da99795b0ca6c6bc5e8d6e84702335063fe9d08b19320c0bc965679c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/aom/libaom3_3.9.1-1_amd64.deb
     digest: 6cfd746dd55a96fca3e058faf82c7400ddf50017bff6f7cfed6ad1f6ee637ad0
@@ -307,8 +298,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libatasmart/libatasmart4_0.19-5_amd64.deb
     digest: b4631b59ed51396e1256e7c35be72f029beeae57b3173aa36a1f58908494a05f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/attr/libattr1_2.5.1-1_amd64.deb
-    digest: fe8119dbed041bd434eb95446560f5d69b08a3080b5c315d27be2f76c41ac464
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/attr/libattr1_2.5.1-4_amd64.deb
+    digest: 0cb597ee040ddf7d7ef5e317060e80842267a27fc8936782482d826900756165
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/audit/libaudit-common_3.1.2-2_all.deb
     digest: 5fcb4f437655bbe179c280be56fdc879d317f6ea6f3a6b865c9fa01a314fc8ca
@@ -331,20 +322,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libavc1394/libavc1394-0_0.5.4-5_amd64.deb
     digest: 27a869ad9b0f6673fe4c6e6dc6aae04f58b550fa9f2de4c9c9ba64cda6e9937a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin0_amd64.deb
-    digest: 5c879f2bb5e245e3620f30fac20b046e2e1770b3db8d101fd3d77f1bf13374df
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin2_amd64.deb
+    digest: 11c11308dd570baf7d1faf87862c8edd5033a648dac4df9b3a14333d339b55e1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin0_amd64.deb
-    digest: de142f9b5e109cab76bf89987b4d32a79a489e8644cbacb11ecc605c290d6024
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin2_amd64.deb
+    digest: 31e17d96ea0d6f9977833e84d40183a63edc56c408874d4b65b120871bbc04d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin0_amd64.deb
-    digest: c8716db260758b9dccd66343c82597ce5f239746288b24687d2c1dacf64d7760
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin2_amd64.deb
+    digest: 274d9c2fc032c05e8681123e433df396aeac198b820bb4de7ddf415f0eb6a6d9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin0_amd64.deb
-    digest: 9744ea02284ee606bfa0ce6243399199a861f8c967d16f2cb23e5e834c375ade
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin2_amd64.deb
+    digest: 5a9d472dc24c2fca1fdb108e4c63c28f1bcd4cf4921e8bdeaab9920b0c4c6cce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin0_amd64.deb
-    digest: a85ec638e75deef12fd30204d63112620d4e21e9a4887ae267081cd7512a4846
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin2_amd64.deb
+    digest: 3af976a0628eafd167b8652cebc99774f561255d338f9e874c9fdf20087e84b6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
     digest: ad82b2de93cc49cdf37c861b03275245318b1555255639e5e805cf612a40171e
@@ -364,35 +355,35 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto2_2.26-1deepin_amd64.deb
     digest: 1bcad2d41d17d258ec2ecba235be7e8c18c50c0eaf1e9240811de45b57c879dd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto3_3.1.1-1_amd64.deb
-    digest: c14fb71789b2ecf36be5b079e48902f755ebd64da0947c82b43f207edbf9f399
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto3_3.3.0-2.1deepin1_amd64.deb
+    digest: 4b89d27ee2cfb574b89b4de455cf435ac01827761f21d0d6fea26a025e551ca6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-fs3_3.1.1-1_amd64.deb
-    digest: 7f51ea006910b783048c7c6e2d65dd834eb344f934c091953575c365a140e9b0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-fs3_3.3.0-2.1deepin1_amd64.deb
+    digest: 40f172bdd71cc9f1109636158b1bd37db36c4062b07aa36969ac06ba854d49c3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-loop3_3.1.1-1_amd64.deb
-    digest: 0b46456d5fed6ad143ca1b360807cc686449ba47c03f96ac5767204105a2a83d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-loop3_3.3.0-2.1deepin1_amd64.deb
+    digest: 282526949cdfb6438737dff087ff3deee390af8087d8a35b9a84838b637ba285
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-mdraid3_3.1.1-1_amd64.deb
-    digest: 2f24e6d4076779fc6f53aee58f2581e39dddea619df0810996dc5684ca0f618f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-mdraid3_3.3.0-2.1deepin1_amd64.deb
+    digest: dfd6dd3dff3cdb80baef39de09dc9ef1de0695ebd321060feffb79b32f7c2383
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-nvme3_3.1.1-1_amd64.deb
-    digest: 64ca54711efc725dad183c760e13206fef61f67f022b2dbefb673041cabd349f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-nvme3_3.3.0-2.1deepin1_amd64.deb
+    digest: 788a6a9aa56041a13390c1f46f5f7a41e29062346101866a41c764640d10776f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-part3_3.1.1-1_amd64.deb
-    digest: 5c25842638f48efcd7b3d31f1240785d1d47e7d03ebdf4141a6020d4d21aeea2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-part3_3.3.0-2.1deepin1_amd64.deb
+    digest: 0d0ad06867a1485b4284c77186c8c751bdb6c8782965224ae47a7424af245953
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-swap3_3.1.1-1_amd64.deb
-    digest: a7a7791b00576ca8a0aa0846460d8aea1fc3eec46f21817b7f6bfbd86652e29c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-swap3_3.3.0-2.1deepin1_amd64.deb
+    digest: 04df25439aa69f33209129c4c58906804c307d25cc5dcac9396d26b282f69068
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-utils2_2.26-1deepin_amd64.deb
     digest: a3a3403628f0ebd8a66eff9b31cd7182c6b233167f07b631ca0a1ef3844355e9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-utils3_3.1.1-1_amd64.deb
-    digest: 45935b0fd056248ec12577b325f3b7ce72a51397bc9a1746a7de3fcda1647507
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-utils3_3.3.0-2.1deepin1_amd64.deb
+    digest: f86738c8e1ebae17c6ece85698026962a2900d993686ae53e1f36862c089cc09
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev3_3.1.1-1_amd64.deb
-    digest: 700ddf9104f37cbe15d77768dbd819e8d082db8ead70a4bdbbc36068a96904b1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev3_3.3.0-2.1deepin1_amd64.deb
+    digest: 9473a4794fb85348c8c7185d022c45a58c5f46ff1129dc1dc240cb55c52c8d8e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_amd64.deb
     digest: 563f4d3b275996192a906b926390435bb3e444294f8766b8db5ba66f199db55d
@@ -463,6 +454,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap-ng/libcap-ng0_0.8.4-2deepin1_amd64.deb
     digest: 7efab9f53195e096021a501e1de215169c3be182d2a2cbdda8d561e68584860e
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2-bin_2.66-5_amd64.deb
+    digest: 61428561e0fdf5ac64fb66b788f1bcf25bb8c2fd513688c27de843cc1ca2b80a
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2_2.66-5_amd64.deb
     digest: f4f581c5ed9c6576ff284117ee51ae8b4e47e6799d71fabc7c0aa2d3a260752a
   - kind: file
@@ -481,8 +475,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_amd64.deb
     digest: 1ee2dbafa2c331d58cf10cdf546c760d7a734c5d9fab1b16d2e04e51f6e38623
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.15-1_amd64.deb
-    digest: 57a3cfa5dc3847d978668e57cac797681cac10be5f6deb6ed3955f23fad0ac24
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.18-3_amd64.deb
+    digest: e638d498f51d1c6b3a67b0463fb57269e996b572f59237b041d07ada88d7a69d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_amd64.deb
     digest: a34b10500cae17c2c122760901c453df850a968a32699978c2015cf355fd5580
@@ -505,8 +499,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_amd64.deb
     digest: a7af8c9a2b767781d83f60fa32553f6a713569a0f7c4666e68dab41c46feaf1c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2_amd64.deb
-    digest: 432092c0719b0112362642094336cd4ff98a18c7ae9576ef9f113d7e1f54a21c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2.1_amd64.deb
+    digest: 612def1dc46e0952a0bcffb16202e5d5f8d20daf5b5d0ba736aa0ce7baa35a72
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_amd64.deb
     digest: 44b5e0a887f8b8d84166ba81f4cf1d70b607914c8b59959c47bde1ce750645bb
@@ -514,17 +508,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_amd64.deb
     digest: c58e37fce60c661d023d37f46d1af34772c40783b2be220f0d11eb8e2d8029b4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_amd64.deb
-    digest: 45ca2c611835e500875ddd500f2618ec97d6bfa51735ec3d276a72fb110e544e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_amd64.deb
+    digest: 57726c5fbe502348eda3a0ba248978a0769eb7fd134d8998386e3216875e18d9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin1_amd64.deb
-    digest: e48aff0e7bd13a310516cfc5dcbdb68d789ef8e4c949afe7e638fb402a90f150
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_amd64.deb
+    digest: c3677b705c3b3214cec20cc24f7a4e4a05c975e1de8834e4647f5f2575b114e5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_amd64.deb
-    digest: 14f6bb47e2fb92849593a1440cd87393d7920f5b7a0fa1932165c6bc8c96e890
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_amd64.deb
+    digest: 94aabf445b3d15c635a2a1710066107e3f3860bcc15cdd982b3ae5581b132960
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_amd64.deb
-    digest: 7e35233d2f74d5344630efc3bb2f91d2efb8ba7e62f01d5b095bb6bacc3c7010
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_amd64.deb
+    digest: 35286abdab600d5aede3a3e77030ad9f65535287d63be8140f0959fa9e0641f8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_amd64.deb
     digest: c8fd9506ce9de38317bc40295bd9c673d332e444771e00c6bf249373e424b82d
@@ -538,6 +532,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_amd64.deb
     digest: 258bd4678ba2f0f0a63f00e630c890efb34a1adf65e1017308e28a16ddd25eb5
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/davs2/libdavs2-16_1.7.1-1+dde_amd64.deb
+    digest: 7f8747a9b3a5322649d4cde69fb09fffb310ea0b02bca7df6f60db383484c1c4
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_amd64.deb
     digest: 98830ff429c7212767f0de4d239870f1936b37527ce365287de30eb8276a8330
   - kind: file
@@ -550,8 +547,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/libdconf1_0.40.0-2_amd64.deb
     digest: 80248ca6b6f089cbf601cf9f5fe5f65f875a291c8413e1c93067dea6ae746f79
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.10.6_amd64.deb
-    digest: 1911929547c8e904871c7377a074fbbd146229621b284de5d57d8eb3bd7a1cff
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.69_amd64.deb
+    digest: 285e3f4cb3b12d726d363283a7f0d6e9300821a7f82ec1b4a070aa769be061a1
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libde265/libde265-0_1.0.15-1_amd64.deb
+    digest: 70349a1252f96e510b63a9f6ae3ddcf0ef771c82f7c0bd0a6931cb83ad4c5305
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cdebconf/libdebconfclient0_0.271_amd64.deb
     digest: 19892f66e35d7f75d1a3d7a2ad53a67af9981a03a352777e07a1e8595bcbf509
@@ -559,8 +559,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdecor-0/libdecor-0-0_0.2.2-2_amd64.deb
     digest: 7da1f884a5e8a8545347bc710eb180a0025272eeda1f5fbf0144d5811fb1cbfa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-pdfium/libdeepin-pdfium_1.0.2+rb1_amd64.deb
-    digest: ce7b5d8b92bb21bdfecba747cc071a7923ca5c31bb56d1934ded96d1ebb54ef9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-pdfium/libdeepin-pdfium_1.5.3_amd64.deb
+    digest: 61798e973e4c60cf2ab8934fffcc94510c17dfcc11bcbd0eb496a62aab98c73d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_amd64.deb
     digest: 04a8d4c536a9f106a9f4b38fdc012fbe745b928e32ef3f05db4704d30c1023b5
@@ -571,47 +571,41 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_amd64.deb
     digest: cd72874d32e4388f985efeec06703b272bc1e09462172dfa52959a18520339cc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn-dev_1.3.4_amd64.deb
-    digest: 38cc6dda883d3361603ac7eed08feff0095a8683c256b85d3a92c34ebf70d697
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.69_amd64.deb
+    digest: 79799f4d58ddd6bd53bad3eb828d9b0060c9c30d6b7075d37d119fcc6c1701ec
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn_1.3.4_amd64.deb
-    digest: f874df0806b19d01b67063614f9ebc8c37e44c438ab238cd3d1948801fe96c9e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn-dev_1.3.31_amd64.deb
+    digest: 0c9c15c5fecae6ce3de13da7a535dce85fb8a4b4c3e2af6c363dce6f41c7cba1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.10.6_amd64.deb
-    digest: ac3f1f4349e4d160e3dc29bc31e10dfc35262773b05180f7b0112443b8c6e36c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.31_amd64.deb
+    digest: fcf8a33774a6ce1aaa432a8b244993ab9119605cf5d5cd63caf25ec91db1ffe7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io-dev_1.3.4_amd64.deb
-    digest: 015e8c7694b873fdfd348d79f65463cec1c895614cffb75e3c188f227c839f83
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io-dev_1.3.31_amd64.deb
+    digest: ec8dddcd968e7816fe5c0360ecf773b07f1aa1e9b871b5882e196c947f3c58eb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io_1.3.4_amd64.deb
-    digest: 5b2f2833c01426b9f5e828e941adca1a20022e54504b387e134e363101d04379
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.31_amd64.deb
+    digest: 29640038e219938479219bcd8ee66bcbbe80eb3a49b8033893a3d6b09fedacf7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount-dev_1.3.4_amd64.deb
-    digest: 33b4e58088fde72718b6a69a5e6db416b851e4a755118ce56c59fedd2bf73933
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.31_amd64.deb
+    digest: 4b52b48a1cae2d698639b03a17ebbfebb9fed9b6774ec35b10eaa7b594b5fa8a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount_1.3.4_amd64.deb
-    digest: db7949793ccac7181a91bd4d610b26c80db7c8431474e8f4cf558d584a7c9155
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.31_amd64.deb
+    digest: e7f3a0684f07c34eea8c4e7537af08fa0b775070084120378d0a1b7b53b62df5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.4_amd64.deb
-    digest: 170be1a282e0b9d8498801d7919ed2495cf4241b5f0a578304d7cf060039e701
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-search_1.3.31_amd64.deb
+    digest: f04b56fad783f6d47fb185f5582d2351409dc2a156ecd1015bccb20db6b03f47
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.4_amd64.deb
-    digest: df5db86d0fe0a1ee209aec1568b7685e2e0e8b44fe845e9ab0c7f1a6c5fe95c4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.5.17_amd64.deb
+    digest: 5ae14324346a37b712b0ba1e2dda259eb49035bb5176c1e4cb2a0e445df3083d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.4_amd64.deb
-    digest: 51a48cf85be8f72645bd2c85c49a88a5ec62a85ba0069563a02493c2fac0603c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.0.13-2_amd64.deb
-    digest: cb78ba057343ebd92bfd5ef643a6c2031115b750471d1173e9e6d6e43c757e7c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.10_amd64.deb
-    digest: daa6077790b86e2904b75316cc899228f41a26b09357f3979a598fb178f6d953
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.21_amd64.deb
+    digest: 0b94bd183f24c9161756c6058e7d24f974f2d39680b0dd9b5adb834c2ba35ed8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_amd64.deb
     digest: e6c6d028a74d0a752ae638ec19b8239f404c36d676c7569936f31000d25a75f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
-    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_amd64.deb
     digest: f58eaae37579b2a3964f84993a8893fe00a05447b23f5e937102c30f64fead50
@@ -628,47 +622,38 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_amd64.deb
     digest: c2f1676c3335ab76ff829190951052abef661b735f2ddfefdb8d6c0698c41756
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.25_amd64.deb
-    digest: 8ceffb3810d88965cf8f4b9cff067f53011112dd32a211495e0c37a9a8a948bc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_amd64.deb
+    digest: dc0e1738af9ccdb458d217b3d2eecb2ffbb49092f6247b6021f786b0548d12b0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.25_amd64.deb
-    digest: 60ed25c9a9cb998a21b97cbd0451f4df0f5bd9f3872eef1d809575eaa6048c9f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.38_amd64.deb
+    digest: 00964a07edce1826a9ca23dc820091f95c77da6950ff704aab34d59ace7bdc3b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_amd64.deb
-    digest: 9a7716eaa20196761a0f87a86035bfb1bb2b0be1bf485b0697a70927f60a99cf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_amd64.deb
+    digest: 242c7b48aac3fe35579fdd2f52cfa88e12a8f0df5ed29926d042441e4d449471
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.25_amd64.deb
-    digest: 2c91aaf3f276058f1c190d355ccdccbe699c6c1b5999edf9256fee34b5343d66
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.38_amd64.deb
+    digest: 43302b4536ee242e84c461c32eff19e794a892636734c15ee2c8094ad77cd28d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.2_amd64.deb
-    digest: 203f1e94dcaa537929ad7df2c33f9ae6f006985fc56829a37c67dce2c11660c8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_amd64.deb
+    digest: f9e6c1e18e5166aea09e13367e954c527f0d8b7f5cbdcbd9493d933a65ec7fd1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.2_amd64.deb
-    digest: 4af48ee588e9a27ca3663193177c4fd2b4e455cff00dbff0aa5fc2ec4bdd24d5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.4_amd64.deb
+    digest: 4fecfdb38533bc2e6b9a16e559cb70c56ec50fa061b92b1124b606d28d7b3887
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_amd64.deb
-    digest: 34b0abc672d2c5af743d1a0836af2a258428422c3d1b87fb71507b0abc8073c5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_amd64.deb
+    digest: 4e0ae6248f9f3c03765a71c4cd4df02f2a7ff242c4e7bb45d1617c9d234084d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.25_amd64.deb
-    digest: 2d4d30307bcc41eb6cef9608603ee999aabf3a81d4ba2a7008e6bfbc232e0689
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.38_amd64.deb
+    digest: 649ec642a62e9ac7aef520a41b14f0d3b09bccee17b4676790ea45ec15a37c1e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_amd64.deb
-    digest: 880d256182fe9891a7874473fdd1f18439e5c1625160214adb9167fdba3159da
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_amd64.deb
+    digest: c490431f2dcecb0bc945f62ce139994ed039098c4c803a14c39b37c65e6d0698
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcore/libdtkcore5_5.7.5_amd64.deb
-    digest: 48031c8e5c34e121f935be4484ba33f0d2709e7991cba9f5ccc822254de79fe7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.18_amd64.deb
+    digest: b68e4815cea197c703fe17fc8cd90206bd6cbd9a582edb909cf8f641ee1e313e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.5_amd64.deb
-    digest: 75824b67ac4979f023f9a22ed326157e76f0c4d7739474145e4b51fdf55f83a0
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkgui/libdtkgui5_5.7.5_amd64.deb
-    digest: 1d9a6cdd48ec586c5bffbc6d59f9dbe614116d0ed4eed687ce5eb8bbd9193fbe
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtklog/libdtklog_0.0.2_amd64.deb
-    digest: c09e76dc4e432430743105e05a2dbd0ff5fd70995ff531ebf28b5cb9293b261c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkwidget/libdtkwidget5_5.7.5_amd64.deb
-    digest: 9ac99a10cfd4fc06154fa2839f863ba0a88c795a87ae6a3872f466b1c7744111
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/duktape/libduktape207_2.7.0-2_amd64.deb
+    digest: 03743b861cdfa66aa9a94608574f3c6c784fa0ede3264e70d436c2fc8e902b95
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdvdnav/libdvdnav4_6.1.1-1_amd64.deb
     digest: df4c7720a1876aa6b21c9f4909e031e005553fa0010f8aef6bc62090775ee2ff
@@ -676,20 +661,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdvdread/libdvdread8_6.1.2-1_amd64.deb
     digest: 4d368cd6e062b88b0f70030b187aab2fa8ffb3ee447aa5c672be7513ec34ddd1
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libdw1_0.191-1deepin2_amd64.deb
+    digest: 195f88b359cb82e017c6960bc4b43ae27d044ac10a367684e07efdbefefab190
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_amd64.deb
     digest: 72d015604676696e4e10e238f4795fbdc3d7c0e241147d55c9782ea8baf9a03c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin1_amd64.deb
-    digest: 87279fae7f9248c2f9fbc9b4031062fe49b51d939203471601b704ffd00b26d8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_amd64.deb
+    digest: bb9a950bed0f7a14f62e0787bc8b650262a6094c5b244d7771ef9f4514a0dfc2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1_amd64.deb
-    digest: 8c883a493c299a9cc4bf8814dc98b8d22ef4902f2e29b84e47c05075807785b9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_amd64.deb
+    digest: 1675190466ac26b2ae0f64131a83aef2663c42ee1c1775aafb2ab6878df3f235
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libelf1_0.191-1deepin2_amd64.deb
     digest: 27dd39d5858cff9969ff58d01f7fe44a846dc9e9477898e250633c7b96c72757
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libencode-locale-perl/libencode-locale-perl_1.05-1.1_all.deb
-    digest: ef71d5b44ceef8015dbe954f6007f7d7fb32ceeafa49c8afc28ea8a79d4e9ad9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_amd64.deb
     digest: 48c0a7c73d835054b291645fa21fd597271e28a6eb98d8b22f2283e364e83893
@@ -697,11 +682,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libexif/libexif12_0.6.23-1_amd64.deb
     digest: 777bcea02800cf2c508fff7e5af7fac426da67dd4d9fc21599f5fb43a7dd171d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.5.0-2_amd64.deb
-    digest: 4d0a6ecc7857dc60dddbbd6872c2587f1081ce0d75b84c22ee8641a082fd6e24
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.7.1-1_amd64.deb
+    digest: 8dcb891102e9f4dd8a9903bffde5576f017d651927538d613b664c92c6130ab2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.5.0-2_amd64.deb
-    digest: 5be8be254b82a58e77549b1784520f1f7ebb395b57982f87524533e1f061f75a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.7.1-1_amd64.deb
+    digest: 5b7f0cea08bc334eb501726e90caa650c72fb86b2fdd09e653688ac0a184bbb3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libext2fs2_1.47.0-2deepin1_amd64.deb
     digest: 0b595c8ee57935a8ae1f2faa12ce8f3ad1a209cad39b12aba0db62144ad9862d
@@ -718,17 +703,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpegthumbnailer/libffmpegthumbnailer4v5_2.2.2+git20220218+dfsg-2deepin0_amd64.deb
     digest: 0f6db203dd26d4eebe637a1e0a50a75c99a2fb34bb81222660307ee6c0a1a9b9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-basedir-perl/libfile-basedir-perl_0.09-1_all.deb
-    digest: 79f5ef747c15be92e24a1adeea98e3d4c01b1b90b730a184a8ca4959a1aa4684
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-desktopentry-perl/libfile-desktopentry-perl_0.22-2_all.deb
-    digest: 19ed7f791a824bd6525c02cc6011bbd614880f3408e78eff5e16e1e9990334a8
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-mimeinfo-perl/libfile-mimeinfo-perl_0.30-1_all.deb
-    digest: 4d9cecdc4b82cee837e74512293b8c84a554d3cdf6c760627cd9c42d6c752b92
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/flac/libflac8_1.3.3-2_amd64.deb
     digest: 176363ec9b23f4b24a1bf8f8d0523eab3a34bd5b5d995c7efa2575f5371f749b
@@ -763,8 +739,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fuse/libfuse2_2.9.9.1-1_amd64.deb
     digest: 48099ee8f8e5a5004869db58b33fed6663a4adcdadf4515bd28de25e59b37d78
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin1_amd64.deb
-    digest: d5e8568bf4722ba1cb7c089828f86e3e7608640010fc85286859b62f207b060a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_amd64.deb
+    digest: 4022d612b88be490e20eea8ce8d3ee2862a2c3fd563e549a523eca14cee34639
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_amd64.deb
     digest: e70f1a5d9e15b85cc026d9a816064453dfb05a78fc4891a3da8b595a67debd9a
@@ -811,23 +787,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgfortran5_13.2.0-3deepin4_amd64.deb
     digest: 8e62468483e18f9922bd64d2874c2fe03b3a9fda23dfa0a04d7e8db0bbf8dd0e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gio-qt/libgio-qt_0.0.14_amd64.deb
-    digest: 4270bb12dec1636b0d8abd20324641a9f0522e00e043a75dd0c5a7ec7cecfe7b
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_amd64.deb
     digest: 6340c9628c7bcfda4c6826a49c52bc8bf28bfb8d12c163eb19ebde7b0ad61578
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1_amd64.deb
-    digest: 0682d06faaefd4fb61e5b8daf45ff4318d9bd96e279792bb4a6eb16b0cc61ba3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_amd64.deb
+    digest: 9555387119d2c7118202da7424f3d95a358843cb6e3369135979bf3fb1e7586e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin1_amd64.deb
-    digest: 273f9c7839bc622c553bc3659b1e1d29cf4d61cb307d0a7dc36937c5d523138d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_amd64.deb
+    digest: e98cff9eb0e1302ecc54f63bfedd21b9b1d96a9aa81f0c224363a26c7380755b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1_amd64.deb
-    digest: 1889b6be38cb7319734d330c232b64aff31845745c74732bf824fe39bcbfdb6e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_amd64.deb
+    digest: a80285158761a0fb609a7a27676b6ba15f9e30b12985012de34ffd84a8d03e95
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin1_amd64.deb
-    digest: 82afd7057adfa2e6a2642b81d319c4815c714bc44b914e0fd6984284f3887f15
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_amd64.deb
+    digest: 90ec3a2e108d28d421cb65fe9245dbeeb0cc923d81f1da45a1af6ec6be5d4024
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_amd64.deb
     digest: 33857078b63370d9edfbceec5a4f8d159db6f75da9f486dd12c97711598f43de
@@ -847,17 +820,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibmm2.4/libglibmm-2.4-1v5_2.66.6-1deepin1+rb1_amd64.deb
     digest: b8dad9e22ca885ff68f7caad2cff65fcb727b118cce08de18483306f7834ae51
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1_amd64.deb
-    digest: dbc3b9a38a5527c8a02d8edf0f87779993272d61d9b24c3209df69d1ebf3e540
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_amd64.deb
+    digest: 58699e543f5a5135c84153224efd63d61c3312201debeb93430014dbd28f313b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1_amd64.deb
-    digest: 31a76ec3d0a13d2340d8f89769770655ead3d477c918082fe4fad249c6d51258
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_amd64.deb
+    digest: 5b8281d799f1b3844524c1baa475e4876665b4d6062800655e180586dc0015bf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin1_amd64.deb
-    digest: 7232cd85bfc774cdd093465273698eff1f1798442b301c462cd4daeb58fb8a96
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_amd64.deb
+    digest: ff5c14a729458868c87b7eaeca9e9dab4c06f2f5eec59d71382d36e36f79f3f3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1_amd64.deb
-    digest: 30197452c9ee62b7a7063d1a9f208ffae0eefec86800340a104a884543d133d0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_amd64.deb
+    digest: c7571d6a7a90722d85f06bda863fbae2a42ab73f0b4162ce89b5b6c87382dc59
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_amd64.deb
     digest: 6f185c6ac2987d5d8ac0f81be7f0377ac34c00ba45ba8d206ae7ef5888bbca00
@@ -898,14 +871,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_amd64.deb
     digest: b4697179666eb012313127a7ff04d286f427b49523f50ada6d593694030c0b51
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-qt/libgsettings-qt1_1.0.0-2deepin1_amd64.deb
-    digest: 3346da2fee0a1e2ba5d2a06e576e6e8a6611e0c073b3c4137968d6a9d207f501
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgsm/libgsm1_1.0.18-2_amd64.deb
     digest: 7f037b2ffe20f167cdac62840fd0a333d15b9a13b58220db8094fdfb081d262d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_amd64.deb
     digest: dfa250b0e4ecb5b3c359f49161b460b0139c38b1592b6d6538395855f6c952f1
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.6-1_amd64.deb
+    digest: 5e0621339870e5af412c689c0fc54313fa60f09c94262689c3b0b8fd6dead35d
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-0_1.24.6-1_amd64.deb
+    digest: 9c73c5986475d18685e16d29ff472fb79fe47bdefa07625b47ef64937f4e4832
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gstreamer1.0/libgstreamer1.0-0_1.24.6-1_amd64.deb
+    digest: 2259037809d8a9295579a9d8d046a0889dfdf6777d8a9cc514dd94879cd66cb9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/libgtest-dev_1.12.1-0.2_amd64.deb
     digest: 6d6ad81fe698a56f8b31aa7776e0526347b83c344651d7a0b4f8ec0625fcff45
@@ -918,6 +897,18 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_amd64.deb
     digest: 29f8f51877821f22adc742cab010c0f627ff4db8ffb03a1479441c5f2061f9e3
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif-plugin-aomdec_1.18.1-1deepin0_amd64.deb
+    digest: bfcc4990b101e8ba69e7e3b62f1bb5c7f06acb9485f143b9928ef995b656efe2
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif-plugin-dav1d_1.18.1-1deepin0_amd64.deb
+    digest: 9361b9c37510512513c87f138f06102c4ec0815efad4cbf88b4387b249218883
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif-plugin-libde265_1.18.1-1deepin0_amd64.deb
+    digest: 14721c4e958b6926be9c576c4ee9a45733f18bed63fd70346b425888a40c6c22
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif1_1.18.1-1deepin0_amd64.deb
+    digest: 6414cf814a8f55b1f53239df48cbfe6cbc931dbbeb26212ab50d364526884b24
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libhogweed6_3.7.3-1_amd64.deb
     digest: 0557f0e34a15444b6792c2726b5d1eb48f9ea8cd42bc7f4d697081e804ced558
@@ -945,9 +936,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_amd64.deb
     digest: 52cbd20e0fc0708991bf66a0af9f5ad9a18d88a7552a8a1b46e209a2f54d25f0
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libipc-system-simple-perl/libipc-system-simple-perl_1.30-1_all.deb
-    digest: a528ecfa70fd8f3b4cc024947ff264e3952b0245be9a7147e556d8e1a037007c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libisoburn/libisoburn-dev_1.5.4-2_amd64.deb
     digest: 4764473830b11c815cae1fff09444b2493a6d85a23efcee0c89a7107a2fddf89
@@ -1003,12 +991,6 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_amd64.deb
     digest: 784e45679941a3e3de3d747f94f215a6fd4b3767aa0b92c4e66a43cc5d628d33
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kcodecs/libkf5codecs-data_5.115.0-2_all.deb
-    digest: ea3e2873fa4d0e0fe356c8de8a93d0dba6dcb38ac53f215a4bce4cda28d63fe9
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kcodecs/libkf5codecs5_5.115.0-2_amd64.deb
-    digest: ef98395670ff669bd970ee24f7fb13202bc6a570a227d15323d1cb99820eeb2c
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kmod/libkmod2_30+20230601-2.1_amd64.deb
     digest: 74372a4857d86e72f473bb48ef74e28aa2ce59909d7f10d756bfc060b735c454
   - kind: file
@@ -1060,11 +1042,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lua5.2/liblua5.2-0_5.2.4-1.1-deepin1_amd64.deb
     digest: 86018b54282cd5166f1d60265fd44914dc29a67364ff72ccf785fb4c9c772e45
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++-contrib0v5_3.0.8-deepin1+rb2_amd64.deb
-    digest: 7378cbe6c63b38e21195ee04e7acff83422fbece97e0d293ac66b49abb78b563
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++-contrib0v5_3.0.8-deepin2_amd64.deb
+    digest: a8fd06cc0d3cd9168372a1749b90d69614a5f0cfb6d0851f96e64cb781cf28b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++0v5_3.0.8-deepin1+rb2_amd64.deb
-    digest: 0359191e2f09e7ad211fa217cefbaf921e716ac46d7dc6d954844a809bd560d6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++0v5_3.0.8-deepin2_amd64.deb
+    digest: 31effa86e58345264e3a07e6d2caecdaf61b00a9a99eaa652d6cb05455d12872
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lz4/liblz4-1_1.9.3-deepin_amd64.deb
     digest: 9808e49cf41c4a38f0ff4f4de7080ae392682f3cea166abc079a26625c8233aa
@@ -1113,9 +1095,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_amd64.deb
     digest: 8da2a921507884c5bb32854be4feaa1fcf5cd51d5d41b413e0f75982ad578a9f
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtmpris/libmpris-qt5-1_1.0.6.1-1deepin1_amd64.deb
-    digest: 60ebebefd0332d915bfc3fe2f3f2e4782f879d12053acf5ecdd548332745c631
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mpv/libmpv2_0.38.0-1deepin1_amd64.deb
     digest: c6b5c572fae1453e8c241d27baf823e002cd3dd7ff4213d0e8c7cbe422a3c33c
@@ -1195,11 +1174,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openal-soft/libopenal1_1.19.1-2_amd64.deb
     digest: 6519188f969234cbdc9e3cb8346d86339b1f766db083e2519cfdc68b917e00ae
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_amd64.deb
-    digest: b91f22b0ab692fa36eff6fe2acc7e5878ab99d56177f3983cec1db54bd9c7f72
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_amd64.deb
+    digest: 178ad33f72e1905c6d777a680fad42295608be7a6f8f95dfe5f2f27dbfcd5505
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1_amd64.deb
-    digest: 85398c86d394fb5d1c7b1f75cc6f3f3045424224493853cb94880a82baaddf8b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_amd64.deb
+    digest: 8cc2d909d52c3346a714c2eb5d0115db214f8aac5eebfb5e41bc91eb48f7f951
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_amd64.deb
     digest: 1d7109a9c3f29c8bde7b4f92866d28860ee641dcfe3a718f4b730f845e63a4a4
@@ -1209,6 +1188,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/opus/libopus0_1.3.1-3_amd64.deb
     digest: 5ac61126fb5114217854990fdf86796f2b8a4c8fb11a29f369e76dd865a42936
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/orc/liborc-0.4-0_0.4.32-2_amd64.deb
+    digest: 45de2342be7747f5d54d521409709d3207a7f6e16ab44aa9a8242b0faf898cd7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_amd64.deb
     digest: 3aae0a4770a313f4092d89d9603472fe9dbc0bfc9e69230868c168b3b30f860a
@@ -1222,8 +1204,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pam/libpam-runtime_1.5.3-7_all.deb
     digest: 28a2789917401d06fff5c31991bf27fc808626c5c086219df63cfe1acf978b97
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libpam-systemd_255.2-4deepin6_amd64.deb
-    digest: e6c451c995fe6f374bb296d7414771795cf9a6dced25a60bcbb1adb4e54d5b1b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libpam-systemd_255.2-4deepin11_amd64.deb
+    digest: 74b88386495e70114edf80ce6b2e9b1a76da6d6dd290a5b51337bf9820c491ae
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pam/libpam0g_1.5.3-7_amd64.deb
     digest: 8d6d9dad048874967ea0b2d95f7370b737916ca94cf72f08d4ca2cd376e83f80
@@ -1258,17 +1240,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-posix3_10.39-2_amd64.deb
     digest: f1d82802bdf71d13b7fe0b95aa0efbef3d4c661920629686170eabaeb8f4ecff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre3/libpcre3_8.39-13deepin0_amd64.deb
-    digest: 66113fed5a1e26e6a762a8c1c1ddb8a6578dd59b6ccc146779345df9d8d87924
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_amd64.deb
     digest: 6338341b375c166ec39e466ef0282642c338d30d028a99414aac2b44a7efc3ce
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_amd64.deb
     digest: b8f9b921c681e6c08abd8d452489762dc8ec3234e058407757f4f383ba2a01c5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin10_amd64.deb
-    digest: 1313e2522efb090a838672ded2d427bbd3853251a2ecef715c406e899ba3837b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libpipewire-0.3-0_1.2.5-1deepin15_amd64.deb
+    digest: 67994c9d88b4d119e50dcc776922af8d6a356bd5b38c144b16c99f07541d0264
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pixman/libpixman-1-0_0.42.2-1_amd64.deb
     digest: 61dfa0134fe4038b88e3e64081f7340277297771d3a7c1667277cb9b992d2d0a
@@ -1291,14 +1270,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pocketsphinx/libpocketsphinx3_0.8+5prealpha+1-13_amd64.deb
     digest: 300815c25c3d2b8aec8dfd4a03fe74da7d6bab832deb21fe5aa24a3a7e390885
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin6_amd64.deb
-    digest: a56e4e77a50d3f726e2c0dcf9135b216167a632d8b05a41de91d7e68991ae3fc
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_amd64.deb
+    digest: 1b67ae47e78e8c2625ced4de739a0bd1362c4e4f3c874360c00646754699ee55
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin6_amd64.deb
-    digest: 6ca8a10b5549cd052c411d9ff4ad6072a3017644992e6e70565327339242dfa1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_amd64.deb
+    digest: c4bb92580ee19b51ab4dbd0f08b0edc1b968a32e718ae3d9615bffa9610ae6d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt5-1-1_0.200.0-4deepin1_amd64.deb
-    digest: fed9ba8ebaed171f9aeb4ecc52064c365c6fe158caf0f4bb61c4118d5c328d71
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt6-1-1_0.200.0-4deepin2_amd64.deb
+    digest: c86682628988277af7cba9108403f6b172632071722857e5a9d2fce05e224ecb
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/poppler/libpoppler-cpp0v5_22.12.0-2_amd64.deb
     digest: 616d62043d3f3c887a34901f10a80c92d94bc604c50404b7db8fdff398cfe4a0
@@ -1309,11 +1288,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/popt/libpopt0_1.18-3_amd64.deb
     digest: 1bba21a3eeb8559a266ca1aa602df76f8d39493c7a4b4dc5e9e65176714ef7d6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin0_amd64.deb
-    digest: dbfdde5ab37b0d154efbf5dc331f8e993f320f8cb31a2ae688ae3f0ef154e882
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin2_amd64.deb
+    digest: 48c14ad01844820e5d2d37b4ec3353529ab7e0eddd277c0d64c863d1258d3e08
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_amd64.deb
-    digest: 01182c680d643f335f63ae38016fef3d5f097ab718789f9aef79de42f00517d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_amd64.deb
+    digest: 4ad4360252e008b89ea7885a7c27e2df5af4a45e0aede319e08b17db3c3af932
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_amd64.deb
     digest: 7a00b4f3ca191e7a887cbfc6b0ed619493bf5344b85c8e823577b115ec34f738
@@ -1330,68 +1309,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_amd64.deb
     digest: 7611dfe764b5a109e1fa516270c304d451aa2980190c480a83b90207a6b84158
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_amd64.deb
-    digest: fef2ce003db442a002e3c874de33656cae3ef4a6d00a2a72e267b386df647945
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_amd64.deb
+    digest: 452e6e2a18330944a7ab46303050baae3385ce7ad2f509a6526c211b077836d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_amd64.deb
-    digest: 192a53ec08eb4b356fcc157b8ba97a4d2e1e4a2d8e8d32e37a9d70ce5ff2ea22
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_amd64.deb
+    digest: fc43de68d925c6bfdf632afeeb053f1b28f4050b197ade1c93b701cfea5aaba7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5concurrent5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 95229a0bff6532891ebdbbff99e9d1c76d12319b6b04d3cd64e23457420aa13e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 827f947abe65c18f979255506073b5d223d2c81e65a2528da21fefa11c9d1af8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 3c7b32f481b4d44bc017945a73a0f92377ab0a11ffab36e162c768280fa4df5b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: b6e687e6926547c0945ff5138495d025ca190f7991b42ea98193c29ef13ec08c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5dbus5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 7da15afc4adac19078605f402e6af56583e4df322a92bc2bf0ec08a203f9eed8
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5gui5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 502105aca897cdf0afa5c95dc143a505df44388043a2e6098528955b81cb36de
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtmultimedia-opensource-src/libqt5multimedia5_5.15.8-1+dde_amd64.deb
-    digest: 83793f792802995c4e3e45b908553880f7d9fd04a3568aeae9ef68f161e42df4
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5network5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 6d53b85e09f43ab9d6cfaf9c52efc5957b708d5b4cdbb1efe39864241dba076c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5printsupport5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: a8e26539b17821a09704d67ec6fb562bfc7a88316b54f9db8a6f357c324a100b
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5sql5-sqlite_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 6e7ec09d99865230a731fc845a98f39981499becb18ae4994eaf89016ff431ca
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5sql5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 74d42d8db188a195caa91d5a7c56b41b617a16e7873db2d1c1b5f5d9fb0dac77
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtsvg-opensource-src/libqt5svg5_5.15.8-1+dde_amd64.deb
-    digest: ec01534caddc2130f4c8570ac5a74218a6f98ca25852a203288556a141bfe7ca
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtwayland-opensource-src/libqt5waylandclient5_5.15.8-1+dde_amd64.deb
-    digest: 736b5ba7f773a36bae3e497bb21064e12ecfbb25401f1f183ef4f0f7e2af1f59
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5widgets5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: c7ae639e299e34d6d7ada2f0ad797c18237f5ce1be33ae674fd3bf9b8b01ff19
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtx11extras-opensource-src/libqt5x11extras5_5.15.8-1+dde_amd64.deb
-    digest: a32b7bc6291e8c0812e0fc46b40bf209b679e7e291b716d5c5e290775229e763
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libq/libqtxdg/libqt5xdg3_3.12.0-1deepin1+rb1_amd64.deb
-    digest: 884adac238f2fec89a00d1771f369d295818b0aed3b8b747c9f8ef22586db3d9
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libq/libqtxdg/libqt5xdgiconloader3_3.12.0-1deepin1+rb1_amd64.deb
-    digest: ea19fd09324682c9356f3c19602fb5752237c0ba2d788f6d872ec2526fb7d2ed
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5xml5_5.15.8-1+deepin9+rb1_amd64.deb
-    digest: 5b309e4171e413c1788b4f3743227d2978c89ce0eef22cccf56c4455c7780a09
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 2b27dda887d891e316750fb1b7bd56fafb097c1bcb0f03e7ae0062561da40a6f
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: ebd40ac7c53cd6b669568467e3b9b010abbc030ea1201662a74e0cb95a49698c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 54dc26fe98838334213678668a1cfd3c020f2f050ed8378c0b8924ec1af8cc31
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 9f7c4a6b688a3c61fd526f22a54959be1a9a5b550ef981a94bf06d7a91e1e4a0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_amd64.deb
     digest: a6864707b38a192dc89ad51546e958fc2095ca3b45e6ee99e190d48ef54793ea
@@ -1399,23 +1330,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_amd64.deb
     digest: 033f970ed9f2486fa265bf3a10332fc18fec0b9d0a83d74ba999007c4d647fc9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 41dd12c029ef2a97fc9524b773c007642948bb0968f71f6dd08538dd03f8d375
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 33eabd5595bcceca83cfd7747d0cf72a6a9fc6555e2ce3e2ee9c5f1abd23456c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_amd64.deb
     digest: 18db346cbe4e81620934c3b232222482f5c1251725516d3fb620c10ef2bb2611
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: d8d2854d73ebeb2607bc90ba83cfa55b67cee62ac055bb1b6228bd426fea4363
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_amd64.deb
+    digest: dbc187ef7ae9fc30a2880002a2cc4bfa132f83dc7c2abff91b480bec6a8fd187
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 7e1f0b187c5e82d45c06a8b3849fcb4e2a6cb6a31b950f7622ead3747009c54f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: ad1be661bc76e8c62bf7c5a89dedffc7e5e3203119d86e2fb9d5747eb93fe9db
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: f87c83461bc1806acf203a7e52a8c47e32aa5e42ede0d26f0ecf8a26bc914576
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 093d158b5adf7efa268a719648907c412927df1ad770c15987bc8c0b48a8515c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 4c1a62bbfb23764fbfc250027bab219087940ba16fa680b1e7348dcf418906f4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 9104c64aa25ec85a9f10a650ffdf1b03aae2321693ad4485d39b67c7bf68ea0a
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: b91d897b49c277334fb8a68dd554e749c24e01b3d989b7e85d4c08eec327001c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 4f9d66873e7e085fb6909fd47be1fd50a41a8dd4b15b38bc77ab2dff42e43cf8
@@ -1435,11 +1369,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 21cd8eda13f476ec71438f56f43ed8933cc0b625302fff4c6f23baacbfb3b5b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 528e27bb9f946d602265cd8a43853f56b2754f3c945ac7bd64a099d7cc589f34
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 1bfbb5f6771c285ef838eaaf429106eecbdd305baf365766ed05cfb7ac78ff3a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 105370dae395895df950cca059ee1d11aa5f6677a554c7331a83bc0da959ba52
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 7af38213ff2d557481dfe8ef0073da0fdc1ad1f70b22116ebd02f4d39bfb4292
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_amd64.deb
     digest: 0e43640fc49faf57d8454012338aac69b638356417a4a2361f3c0e47271ffbf1
@@ -1447,8 +1381,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_amd64.deb
     digest: ba29752fae4494fe62f5a4d3f139386078d8beb74e53eee1d7c673028a8adb97
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: ae45f73efa9232cbb98621c9ecc12488a7ebf687eaf9866c2e171aa37efd96c1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 9cc8d7cc8d4290b937bcdcf36c18e63293cbc32821a14bf78d69d336dde918e0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_amd64.deb
     digest: 5a2a509181e35a92f6effe0f2ef107c7dfadccefde35548bb1ae568aea003fb3
@@ -1456,11 +1390,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_amd64.deb
     digest: 70486bbc5555f857aff3ca539dea86df4f800d20ad4e20b3cc5b62b9a6d75b21
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 4ba7721998329f33d49cc6f82add0a1a6819b59c4c8ba1e82dd084bfa3235ca6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 3ee17d593ce177df59677046e7f5a8b62e5f30143a824d6b7dadf327da631d24
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: d311d6a7a8cf93949f715bbbb271149e3396966a60611a086b05b125dd17c77d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 7ee33cd4857e0c72a6765d62d14d575ad3abe1e74436ff8615f0659c46e60d71
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_amd64.deb
     digest: 4b74d4425bcb1d23d7763e62cb1c9f2be712d9f92e46542151125ba96d623164
@@ -1495,8 +1429,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-4_amd64.deb
     digest: f02625e8d695be6bc1aa9531c5177097ec906333b60a0fa15861a82ade617762
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.30.11+dfsg-1_amd64.deb
-    digest: 8367935b2d0835c876bf17b81f5b2991688c525ceecc476d1b7da6ddbbe9e22c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsdl2/libsdl2-2.0-0_2.32.4+dfsg-1_amd64.deb
+    digest: 1b7f76a51ac9ec119bdaa143b6eda92006009566c28ec1b13f1aaaaffcea9ffa
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libseccomp/libseccomp2_2.5.4-2deepin1+rb1_amd64.deb
     digest: 8521b2d3819cab1ca6c752bfff3a35a7e57cd57f5acb0680b8dcef583723c54f
@@ -1582,11 +1516,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sord/libsord-0-0_0.16.14+git221008-1_amd64.deb
     digest: 10dcd94952de8e379983b3ac597802fccf58aa0f11b23dbe03f406a71e08135e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-0_3.4.3-1_amd64.deb
-    digest: 9888c53cf0e3cedfe9c8f06e3e08d225b063843874a74f9d74518cb25fc182e6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-0_3.6.5-1_amd64.deb
+    digest: a4b1d5eeb4a98bf8a3d33974b46da58776a9ba8cccbf35b297c43c460e578683
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-common_3.4.3-1_all.deb
-    digest: 1591543d840396ea47f24a2b3287dabc0a50eeb085e07f0807cd99a4ca992f13
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-common_3.6.5-1_all.deb
+    digest: 1ea79c817fec9cdbea2a333656efe9898ed4a7492018321c6b8a1a12a013ae35
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup2.4/libsoup2.4-1_2.74.2-3_amd64.deb
     digest: 976af8e4212bb93c17f77d29e0750072072a3e7804a38bc3e64f45732a7b4594
@@ -1597,8 +1531,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_amd64.deb
     digest: 9736df9018121b8368b482278a533284a82da09650baa3cb3541fa58cfbc09cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin10_amd64.deb
-    digest: b59b38d5fc0284fb0082a4bebbdaea0bd36ef0ae00d520a02ce2ee0b442b7dd1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pipewire/libspa-0.2-modules_1.2.5-1deepin15_amd64.deb
+    digest: 9fcc5140e096484a5a32d3dd3824ad7315d580a24e2e6ee7035a20608f0485ce
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_amd64.deb
     digest: 44381cd9ad35fa6ffa7a0b3e27611011602bb32093efaf0c80117dc9f97a371b
@@ -1621,11 +1555,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_amd64.deb
     digest: d24f878a3059bc9cfa70dc1053cb1a2aad772c63b8bc528d4ad47b089519c017
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.10.0-2_amd64.deb
-    digest: 01518dc04074da312967d3de567241403a8e4a28bcb932cd0331edc96cbe2220
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_amd64.deb
+    digest: 90258a13940712eca57406b2bb0d274fbdaaa2d62a45c1e60c5b123c4080d663
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin1_amd64.deb
-    digest: 9a4e8cc759832d24fa15edd6d45cd2c54b0aa619104969600da2bce5a3d9be02
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin2_amd64.deb
+    digest: efe5ea0c1f74ce2ee8c760ba534276c01c0b347fb7eac4285f79b935bea8274c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_amd64.deb
     digest: b0e9783da04f53ba8da97660523021322c4477059c63d3684fab283b7f9aef9c
@@ -1636,20 +1570,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_amd64.deb
     digest: fbdb57f1b3b245ef8d92d7a29bd0b054fec010ffd245b1d633172674acbdd7cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin0_amd64.deb
-    digest: dce0e6c6a5b69fedacb842be249acad0eef03fc1f76c97ded590dbe31cdacd45
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin2_amd64.deb
+    digest: 6dd0610dc30fe5bb3a72788b563a8c6b77aa2ff482f3394d9f7e4bbe8f8ec74a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin0_amd64.deb
-    digest: 2f6e7a4c570e99b590b1d3a78c2cfd96bc4a665de3e631b292180336af31440a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin2_amd64.deb
+    digest: 9889c27469bacd09cbaf06ceb3f8c7b0f3210248e79d120e68b434e2adfbcb28
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
     digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd-shared_255.2-4deepin6_amd64.deb
-    digest: 8d9db4061d1ef11c0b7a16c0ddadd7e7d0ade970dcea6dfc529c271cff3ca531
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd-shared_255.2-4deepin11_amd64.deb
+    digest: d21e42102b05f37dcc043eb00df9c6176f8f61f3848ea099ea6e7b8a719a205b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin6_amd64.deb
-    digest: 3312bcba7313d337154903b622051f5fa06610a36921c40e3c35686c53dc4d2f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_amd64.deb
+    digest: 75f4b1c1d7e0caf4127313225fb3be35243b09df4cf93e0225f5fb27e6c4074d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_amd64.deb
     digest: 4fdd6319d141f7950b7a0581b38a34f9a2e63f35a8ff38b2ed13a7a77e80e90e
@@ -1708,32 +1642,68 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tslib/libts0_1.22-1+rb3_amd64.deb
     digest: d7c7fffd808cd0b765d2287b98bea752d740994788dbf90de6db4f9710e41162
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-mu0_4.0.1-3deepin1_amd64.deb
+    digest: 62097196d9a0a4733b3a56d3a36625e2d536b6292e18cc7d6a4302ee37de451e
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-rc0_4.0.1-3deepin1_amd64.deb
+    digest: f7d48530becabb1ed24102bcb2a3b0e460b68be3bbabba86c24a39ff7ae807a0
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-sys1_4.0.1-3deepin1_amd64.deb
+    digest: ce47f4a14d736cb5822466b4048f2d42d13e53372904af02fb8bc9a27b0ed5e9
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-cmd0_4.0.1-3deepin1_amd64.deb
+    digest: 74e05df8cf9bba8f0e3bbc4acc597b1d0ccf1a9cd65579ba64373406d68554c3
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-device0_4.0.1-3deepin1_amd64.deb
+    digest: 203fdab84f2e07c30669e2c1bd4f146a2b75886f1268af6f8f34de8b610a0ee7
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-libtpms0_4.0.1-3deepin1_amd64.deb
+    digest: 5e433c4faa2a1a3ce1d88e57b8a8e2c5fd6c9a9352c7d250d21e56972804211b
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-mssim0_4.0.1-3deepin1_amd64.deb
+    digest: 77f2f78d83d44f859f5429918fb8bbc707cb85d10c020d0fd57703b99ad79ea5
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-pcap0_4.0.1-3deepin1_amd64.deb
+    digest: 2d0efc10976da863e747b191195a85a0b30f38aa2bc022196adf44703354a46f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-spi-helper0_4.0.1-3deepin1_amd64.deb
+    digest: d7a356c0d648be79162dcc3f4aa293c45a851d94a694ee8d87aea4d1d9cf5815
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-swtpm0_4.0.1-3deepin1_amd64.deb
+    digest: 9c363b7c37a1b8686dcc1a11a9c1b804f64075fe05452570767ef680f160172e
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/libtss2-tcti-tabrmd0_3.0.0-1.1deepin1_amd64.deb
+    digest: 8b08e7098cbfacffdc4afec1e37551bc208bda31efcc1468eb7e27e0d140fa5c
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tctildr0_4.0.1-3deepin1_amd64.deb
+    digest: 3c61f3878d02985a3b5a54bfb8e885a76ae67128bca04eb43e8a9219966da3c7
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/twolame/libtwolame0_0.4.0-2_amd64.deb
     digest: fdc576e8da6c75367f25d569902e6217db30f61d7865f35d43a53d824856c974
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/uchardet/libuchardet0_0.0.7-1deepin0_amd64.deb
     digest: 8a09c59f9380ce99a5d18d8e3d4fcb1b9308a5f40789b1fb4323e0fb75c51a7d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin6_amd64.deb
-    digest: 33a4c4b97e84007a18e94a6d0a860a493780cfba28d2f27b416931d8aa6979d6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin11_amd64.deb
+    digest: c7acf7afccba7ded43d8cbd42971a6277a597e1dc1190726cf38667369acad35
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libudfread/libudfread0_1.1.2-1_amd64.deb
     digest: 5ebb4a61642a553212842e52f9bcca0bcdf2fa47f95d8d1a4b30d6096dbda8e9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin7_amd64.deb
-    digest: fd0f890c9f9a512bbc9da328f1ed93e7f2803ed0fe0ddd96a740e471bf28c7cb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin10_amd64.deb
+    digest: ec3e61f20da5ed81b4a1c455b690eae010801c7a5f797fdc581fcd98da0b7888
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin7_amd64.deb
-    digest: 6fdb045767176891bf241efa4a33f9daa7533b80fa5c875a9af48680b8dd3b0f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin10_amd64.deb
+    digest: 9540c14a3cb8fc2edddb6a95d0383e2b0dc1d61f275a81fc57ea1d7e9edebec0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2-qt5/libudisks2-qt5-0_5.0.6-1deepin_amd64.deb
-    digest: f6c839cdfb569b151204221be451c5959770b80f42f1e2c497baa250710a34da
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2-qt6/libudisks2-qt6_6.0.0_amd64.deb
+    digest: f6c91e3245e276297b554fc296f9f9a903110d527cba6edfe0630a7e29056fda
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libunistring/libunistring2_0.9.10-6_amd64.deb
     digest: dfa507aa9982a3ba8cca86bc571d47e0c30d8adadc833e16cba4edd6e4c68155
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/liburi-perl/liburi-perl_5.10-1_all.deb
-    digest: 485904ff807b96c4d1d18d248a40b01915d37274df732235119ecd2af01f872f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libunwind/libunwind8_1.7.2-0deepin2_amd64.deb
+    digest: 56d808c8a417c5e6cc2357f19ffe6c6ee1393d9428d4de505f850eb85c371315
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.24-3_amd64.deb
     digest: e719be9bc84266bd81d01ca2dae17b3e8e029ee2574bd1afb82209a11fe6fd31
@@ -1852,6 +1822,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau6_1.0.9-1_amd64.deb
     digest: 0d55ab9b5634a7b635ebe263526719f3c5c925d847c0f4cb927bc61584cf269b
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xavs2/libxavs2-13_1.4.1-1+dde_amd64.deb
+    digest: 09d132f43d700ef33f16c03354ae02d28a79755e92d3701f8e5bf15df0fa4ff1
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_amd64.deb
     digest: f3575052a14a5ec2d016bc667d466fc5bceec389db5b6ad9ab03ca53b50411f6
   - kind: file
@@ -1896,12 +1869,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_amd64.deb
     digest: c32ee9a285da0ddb94ab374cece23c5403e691539b5d604a1450f5120485d18a
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xinerama0_1.15-1_amd64.deb
-    digest: 10b5cf4aa80e70de0a4a8f1652b8c43c8bcaefe8e1d2fe2856ab0731fbfc4e41
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xinput0_1.15-1_amd64.deb
-    digest: e71f83ce673cc5b84531b5c84d2ff7b1616967971f859d7724ae0130d0291eb4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_amd64.deb
     digest: d25d2db11b35fb8d8f7122805028094a0df945c59941f9b726b64dc48d0bf515
@@ -1999,17 +1966,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_amd64.deb
     digest: 2ea949de45dfe27832a6e7816a03103dae4ed45ba2b380669de5d5c89c361cc5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.35-18_all.deb
-    digest: 1fc738c696936a298eab3f5a6061ae0189078abddbdf7ef3da2b39537d47aa85
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.43-2deepin1_all.deb
+    digest: 8c4f70100c1fcb2755b08644f2326f0c42cf037e89c22cb69e4d0dd0798cae8f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.35-18_amd64.deb
-    digest: ccd6ac9289590f2fe84adb7cbe5f4aa0b6da77a316dc818c3244488daf098f48
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.43-2deepin1_amd64.deb
+    digest: da30868c3032f3dfb1f028b73f0613b781c331741fbba8938f9d1a52dbbb1677
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_amd64.deb
     digest: 68fe4a526d73dd2ff6b75c593a5a4059486d1ec2535ec5e42cc52057a52744d2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.23_amd64.deb
-    digest: 910b0e2a76285993e3286050592628ec4c7286a4e7d39e438c3f89019db69a30
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_amd64.deb
+    digest: 46774d4ce9af0864f44fd0aed7cac874abe926c2ecda9845657acd3e68d1fe66
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shadow/login.defs_4.16.0-7deepin1_all.deb
     digest: abed558f44fdd893df5020fdd787b2ee1b5cbc8b5e4b78ab4b01b8f1cc1aad08
@@ -2029,8 +1996,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin1_amd64.deb
-    digest: 348ed9be3dcdf49e393c4a6071c60fb6c7d1f133db1bdf3a9843ab60828524fd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_amd64.deb
+    digest: 9f832c60e3739ceecc42e8d2609e6b0304060479a11d8a4703396b52081e7073
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
@@ -2040,6 +2007,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nilfs-tools/nilfs-tools_2.2.8-1_amd64.deb
+    digest: 962be8d15d6e2cb21f612d75a7e8d3bda923b1eeb38b3836870c4da22de593ca
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_amd64.deb
     digest: 752849bcf3692f005746425ed4307477b665ce980135c7815538a2053e4cbfdf
@@ -2083,11 +2053,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_amd64.deb
-    digest: ad3ff722bfadedaeea33599b5ee43e88f7cb0c3a5f9185348058d0ddb7c9830e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_amd64.deb
+    digest: 052de179f77f52e03dc62849e569130457275528003f3c66b1633aa46750a995
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.4-0deepin1_amd64.deb
-    digest: 5cf3eca309d9562d2c4b3102dc4fe89db6f670e634066d70f1d3c0af2843c852
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_amd64.deb
+    digest: a0ffedb8e24dfed01e29acc8a207b6e90d40a0b1b1ba39dc5c9c2c51ec7da796
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_amd64.deb
     digest: 3e3840ef15b198763d57c130ef9675a46fbdf534f2d5d721f8ddf91b6d743c1c
@@ -2095,11 +2065,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_amd64.deb
     digest: 1ddd2f46a8e6b858e589bb011fcafb498ea673c78dd248283284b8a188cf996d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 2bd4061502b590e7e78fd5cfe089eb7e7fb173a15fed2ced98b50737549b8208
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 32c3245be7c5c0a778f7d6923c6d0f244fa4a297923d96d0583742477e61a540
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 17025348f2c9c6a1dd0742d8559771261dd4d297c9e3fc856ae8ba91a0ddb6bd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: c7bee095c8c3d51a32db1369e90aad0c63339217557b13e494c1ffec0a962abc
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 359f5fd7d83789deee753300437ea35ef2004a4ac03c5367249246addcafc210
@@ -2116,14 +2086,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin3_amd64.deb
     digest: 3d085645b72fd257f6d9f4631b123121706e2926fcf19d8215dd93cc01ecfc40
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtimageformats-opensource-src/qt5-image-formats-plugins_5.15.8-1+dde_amd64.deb
-    digest: 3c630e56673d5358209521ca18e2bca38f50f9c7372adc839e4150a947ec55c7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 8b33f401a988b6afda0ffd807fcbdad2a4ed487aa3d81e66e62d499b1b7a4510
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 216615817367297df6cf55a42109f53ecedebdf973ad3ee5aca0a8335774c65a
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 655b85be8e6045818776113a226aa32bd3b5aee2edd6db07ad86ea65e565b490
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 30382213970c6d9ef9d09b54dd5d3f6088e7e740382edaa457fa2915e8e527c1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_amd64.deb
     digest: b9e766a60ff54dc40cdd1307aead4f3c2c1997388e21fe36ec37650bcf650384
@@ -2134,8 +2101,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_amd64.deb
     digest: 9ebce5aacbc3bd447f6fa109d03647369ec93d054f45a4b6f332b2643ebf9c0e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_amd64.deb
-    digest: 5264d118de60afa8f15122126da05a7663ed8cfe0b592bd9de18bf290f26d92b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_amd64.deb
+    digest: 1e7728aaa16cb4ce8b9baad38f9dba7d047b54a87d3d3c130b3f76bb54ea4212
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_amd64.deb
     digest: 0acef551ad9074060268eabb8d0b2b4703b005b00672a23406346e19d7346de7
@@ -2167,17 +2134,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/socat/socat_1.8.0.0-4_amd64.deb
     digest: 6c7fb6cb82ff6ce1936938df22f6b49497ddd6d5dd6c647c859c5e7b88943f9c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-dev_255.2-4deepin6_all.deb
-    digest: 41bec4491af5737e55f1c186ec8bd05d24611dfaeda7132354e75ccb6ea7dd68
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-dev_255.2-4deepin11_all.deb
+    digest: e6e0aef2dbe6f5df8626b630c52d8d63830e2979730b54839e7f84fbdbe34597
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-sysv_255.2-4deepin6_amd64.deb
-    digest: f4bd7b9c80e3a8a3312f32eca43c894823867f536e8e27b2ee3751ba2290d829
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-standalone-sysusers_255.2-4deepin11_amd64.deb
+    digest: faaede9623a497274944b2273a04817b238b738872fcb91a6ef63f0bf04bb70b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd_255.2-4deepin6_amd64.deb
-    digest: 00522dade3fc800b9039be1ce3433c3604981ec73e2064e4a680566cdff90481
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-sysv_255.2-4deepin11_amd64.deb
+    digest: 1ddf31ee6a704d9fc974966afb19b21c982038edad9f3b2563dc3853cf5695b8
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd_255.2-4deepin11_amd64.deb
+    digest: 17ab6ff36979f4ca80d8f49bb612938a3d244f32b761120ace1a1d0168f251cc
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tar/tar_1.35+dfsg-3_amd64.deb
     digest: ee27ac0010bb1525067edda7b6b86110a00550232fb154f87491dbc3a3a2c8ff
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm-udev/tpm-udev_0.5_all.deb
+    digest: 8305c01b236dc4838bfd5f3331c403ed344207b35808d4bbb76dd58471a65b60
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/tpm2-abrmd_3.0.0-1.1deepin1_amd64.deb
+    digest: 0f680646b0315a0e23b3c1eff233385b6c99ae62ca0abd3985a0035fca28915b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
@@ -2185,11 +2161,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/ucf/ucf_3.0043_all.deb
     digest: 798643dc75a19ab6e0067fcd63a89c28f711c3e4769435e262dc36bba18f9a2a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/udev_255.2-4deepin6_amd64.deb
-    digest: d9fac4347299aef24fca8696308c103ed2efd3b387af4384ad3841fd210984d2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/udev_255.2-4deepin11_amd64.deb
+    digest: 1407631a3cb960ef1df9f2255a5237c92b8e5d74a165f46af62ab985f6969fcf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin7_amd64.deb
-    digest: 23af2e5ba810974cd5a0e2f707998427e0a6d1caf4f1eccd2164b63cc790d3e8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin10_amd64.deb
+    digest: fc31376fc7a62e2c0d15a25d28016cede085203ea51b17d8878caac0399d2042
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usr-is-merged_39+nmu2deepin1_all.deb
     digest: e8896ae20e16a3b4ab0ab4caaadf884de1c0056ff449f85ff1426415e8758a3c

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.20.1
+  version: 6.5.21.1
   kind: app
   description: |
     font manager for deepin os.
@@ -79,17 +79,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/bzip2/bzip2_1.0.8-deepin1_loong64.deb
     digest: 08d9f48f571bc206fe4e30a27e535a3a086b9dedba4a5f5055e898ff0dbea7a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-3.1_loong64.deb
-    digest: 41c50dad5e3b6af472e6b802112255405b7274fb33294f4ef30dcb150309e04d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/coreutils/coreutils_9.4-3.1deepin2_loong64.deb
+    digest: f7223df3b9ff013316554cb9a3a404306cdc0b9428a894758a31c664036dbe1a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1+rb1_loong64.deb
     digest: 6bface8bc94c5da84250e58d56df4bd774a6e3eb7360edd6155416cd44938ffc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2_loong64.deb
-    digest: 54c83cff0f70b77841454545cd9fe439c36284971788ca26115bcbf420cc9649
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2.1_loong64.deb
+    digest: d8915b3382c924164b71c2cb4daafd08b3e2727ed426326f13ed9ca371386aff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2_loong64.deb
-    digest: 9ab07c6f920c44a7c7220f733792eac9496902dbcd1812830f25b0edc1ece931
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2.1_loong64.deb
+    digest: a79946bab6773fbd759b790fb74369fb5b6eef34e388cfd15ceec8eead15825d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dbus/dbus-bin_1.14.10-3_loong64.deb
     digest: ce3e9d3d45cdbf7b95c18d4a5f897ee5394e658b06f2f2f489b1305d675b0781
@@ -118,29 +118,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/dconf-service_0.40.0-2_loong64.deb
     digest: b363f4660223cc03a32118194cb895f40bf489d20bbfe2cf165cf44fff0f9240
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_0.0.1.16_loong64.deb
-    digest: 19fb0bdf1c042bac06516442352a4191c0159369a8df8ee6eb23950de7bc0efa
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_1.5.5_loong64.deb
+    digest: 427de621b5aebd34f12d0fd5baadb239fdb3bc838d5da4a2a85eaab823b19e86
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-common-plugins_6.5.10.6_loong64.deb
-    digest: 0f8d2e9e4fd805ddb1133b2b4404981944da35cb2ca7244c00e3fe9f88431f8e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.69_loong64.deb
+    digest: 1bd992b91bf6a213699c489730e8a58f8678c6df2abd677cb7fcb4fc844faa39
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-daemon-plugins_6.5.10.6_loong64.deb
-    digest: ca8c409cd5f11cd7f2e34bae5a9e82ca394f46c62f5533092ac0e9e04260b0a4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.69_loong64.deb
+    digest: f46ac8468d3f664d10d481e6e805e88b50c9fc2f997bd1c2c56a10c9a68714e2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.10.6_loong64.deb
-    digest: 22aa951af206dea76163afe9ede3a5afe9fe9a88f9dabc16030958d8871b642c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-plugins_6.5.10.6_loong64.deb
-    digest: de5a66d83c03fb6d424506f5884951f71a09766765581a7b52f735a68cef668b
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-preview_6.5.10.6_loong64.deb
-    digest: 558d0c498d41aba9ffe14ec9ad5106e97b1442d7951057b9395ea07702549457
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.10.6_loong64.deb
-    digest: 45216e9e4b20057e2d0d167ff5e5e8f44c680cce460ca82b09061d42333601d5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.10.6_loong64.deb
-    digest: 35937cda78602907b6b19affc84c16dad1c5fde89d56ba35bd0ffcac044de36b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.69_loong64.deb
+    digest: 3076e83ef67167ab7c5f7b3cecbf1ffff8a7ab0ec7f93ca7157621256c30395a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
@@ -160,14 +148,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/dmsetup_1.02.201-1_loong64.deb
     digest: cabbd8c3547b8dada85be41e44719526d8dc478f35a50d58b26b03ee293d62e0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin3_all.deb
-    digest: 52e7455da433b7e412afeec3848d3f6371a857653aea02d1a6e080db446f51d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg-dev_1.22.6deepin4_all.deb
+    digest: 8b3ec535c58fd4041effcff798c688ab1f4a36b6c2ac5989412020686c7607f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin3_loong64.deb
-    digest: eea7a8587865789ec9f40ae9c3e5310f82a5c8c295b27d65e91627c86c107951
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/file/file_5.45-2_loong64.deb
-    digest: 95839f8cfef56aaccf66681c5d22df201d383ac66e3e91aaafd836bf654dbec3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_loong64.deb
+    digest: ed2c4a87410d3beea4622bbe835dab07b458a8e286be591ca34e97f2a6f6d730
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_loong64.deb
     digest: 17c510572e0a51ecc5a4eba486a1cfcb55d2ac297c84f35bc7c58cbc31e6471b
@@ -214,17 +199,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsecret/gir1.2-secret-1_0.21.4-1_loong64.deb
     digest: 5770bc5dcc6da72cad3770a54023a87e2e1af8f5fc179def0a33ab3d0a79866b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin7_loong64.deb
-    digest: d8994f29763656aa045bd17b9d84b5e152b497b13d934ff6c7bbd9e1b809fc6b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/gir1.2-udisks-2.0_2.10.1-6deepin10_loong64.deb
+    digest: e7238243dd4fef2be5c4430f140546a8b7fa7f60cab873e6c3b75bedf2da780e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-common_2.78.0-1_all.deb
-    digest: 94bfaef9228159f8a2f366b9962e5bd82c9ddb53228b161d62c6f5d48ecf1c3c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-common_2.80.1-1_all.deb
+    digest: aa697ddbd07ba9e16391bd81f73661b2583859c8671d1ce92f28e6a870d37059
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-services_2.78.0-1_loong64.deb
-    digest: cac2038581c8e79e1d77222b2bc658572c5bda68ec2a84f2850928534d7a899c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking-services_2.80.1-1_loong64.deb
+    digest: a3720e61312a6775b68764b73977fc598896cb63fa4dd63ebca4fac0a579697f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking_2.78.0-1_loong64.deb
-    digest: 388e3237a15d2e4b1e7a685f569dcbc4583f0f271650262ecae55508308ee0f6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib-networking/glib-networking_2.80.1-1_loong64.deb
+    digest: f0b5a9dbdaefa464956ab3b3c6aa383a0244ebf9f2386cca3bc4e5d75cc1cb07
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/gnupg-l10n_2.4.5-2_all.deb
     digest: c9e04d548f5db44bf2772cac43a1fae57f0711e9ab939d0b8eaefa284f50df0f
@@ -265,14 +250,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gvfs/gvfs_1.54.2-2deepin1_loong64.deb
     digest: e8bc05b296223762a5eb962f517d27b6248d067799d19ef482a10fa90aceb8b5
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/hello/hello_2.10-2_loong64.deb
+    digest: c1392f82149a302cc2f202142ad5404e7a227d9c43267c8f7a4518620993bf32
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/i/init-system-helpers/init-system-helpers_1.66_all.deb
     digest: 60bb52a4118d514e4d480707329a798ae21d135a96ddb9811d7e6bd0e7f2101f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/iso-codes/iso-codes_4.16.0-1_all.deb
+    digest: acd8d976f1a757da000d9ea9405fdf80194a6275fc93fc472e1df1dfa5b301a5
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/keyboxd_2.4.5-2_loong64.deb
     digest: 47b83fc0454babf0e369e111d3010ff3de0fd00d388c375b641af788a6f39b3d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-1_loong64.deb
-    digest: 6a5d883c7ca1fb96e88290e5f80f2310b83e190d02133676ef19fcce44b5fc39
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/acl/libacl1_2.3.1-3_loong64.deb
+    digest: 7388773fe6ec2b0439e0383023e06d26dee49dc9a2adc9b0969c3e24a51f09e7
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/aom/libaom3_3.9.1-1_loong64.deb
+    digest: 22bc30a8ead069539d5cad4100b0141198b3871fdcd5253189c5bfcffd14cced
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/apparmor/libapparmor1_3.0.13-2_loong64.deb
     digest: e36a3df3b4edc54926271c4efb8cd9070de991d40ba4b23a7462ab1296148e91
@@ -289,8 +283,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libatasmart/libatasmart4_0.19-5_loong64.deb
     digest: 553bec6f40a705a86dc5ad8e7b24ca73125908db518817d321cd14c13aca74c4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/attr/libattr1_2.5.1-1_loong64.deb
-    digest: 405e34b981984b1e6d04b5093fdaa36013459af4687c62c3a7dbdd0b42766ecb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/a/attr/libattr1_2.5.1-4_loong64.deb
+    digest: f9965bc423eee241336a5edf4851ebe8058fd76c5ef227d59d57a4e7accd55bf
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/audit/libaudit-common_3.1.2-2_all.deb
     digest: 5fcb4f437655bbe179c280be56fdc879d317f6ea6f3a6b865c9fa01a314fc8ca
@@ -310,6 +304,15 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-glib1_0.8-5_loong64.deb
     digest: ebc3e9878fe6e898f3dad29206f6ed138a6d4fd3bf3137313ddf1f3dd14c6f26
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin2_loong64.deb
+    digest: 7a20afa0f9aacb210e8aedb636f8ec29905d19c8862664a4bc898e89c4a4ccc0
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin2_loong64.deb
+    digest: 2423da906a4fb65e9abf19a59910c614e58899ac2e4aaa522850cad7bb9576f6
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin2_loong64.deb
+    digest: 356dfdd307a6a564c2f253378fd07f5925d481d84ea650d5aaa922009dffdb8f
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
     digest: 43c9bedf808d5c2b85351f73dab25e81c5674c499c293be875ac5250c4b8cca0
   - kind: file
@@ -325,35 +328,35 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto2_2.26-1deepin_loong64.deb
     digest: 000fbf384164b48eeeb7a0f70dd512fd2bd473cfdcffedd841a3038f60b9e0f1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto3_3.1.1-1_loong64.deb
-    digest: deb78811fa1f0e8360316cffb3f1afc397ec98deff244b311d6113022abfc3a5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-crypto3_3.3.0-2.1deepin1_loong64.deb
+    digest: d2e658f8fc8fbd69dee729bf158d21eeb711b3870cc879683d8c90ea85ace3a6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-fs3_3.1.1-1_loong64.deb
-    digest: 07f5125539e2f7a70dcf2ca7d36883e79b22f15345126db188583eea534e9f92
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-fs3_3.3.0-2.1deepin1_loong64.deb
+    digest: 1027cf514722a9c8a6095c1070755200bab61fd440a89a66467ea84a139ceb4f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-loop3_3.1.1-1_loong64.deb
-    digest: 2b2bb2f62425d445329f333553c0323b7496626473c125a74735fdc66a890b19
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-loop3_3.3.0-2.1deepin1_loong64.deb
+    digest: 4527c5f763d39b5131557322baea8df9a82b61c12f477bc1c9756a8171212e9a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-mdraid3_3.1.1-1_loong64.deb
-    digest: 0d565f7cf8d158d66ad3570e3eb98b0dccf45118c1902c3332f4296787152e5d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-mdraid3_3.3.0-2.1deepin1_loong64.deb
+    digest: 2fe81bc280ad22f72172d935e28f075b3b60ceb074291f1e2471028bd4e336a2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-nvme3_3.1.1-1_loong64.deb
-    digest: 7444f4a8ac1c322ef54483cec305a9ef9b3d4681f985e9401afaf4f8b8179044
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-nvme3_3.3.0-2.1deepin1_loong64.deb
+    digest: 30a1c9eafac992a4b82c3233d8c83031703b063b90b324095c9fd0494961833d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-part3_3.1.1-1_loong64.deb
-    digest: 8ae151ab2923527d62233b13ed8e6583eaed28ab6dcbfc0d795a667d9837b4f5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-part3_3.3.0-2.1deepin1_loong64.deb
+    digest: 85d93011b27f7d77d3730bfbe1a9ecab28e8203f16f2fe9306eba5a13855e77d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-swap3_3.1.1-1_loong64.deb
-    digest: d8a548d1e5281b0844f844fd64d1f894d7f1cd5d8358a96a38241e030278ad55
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-swap3_3.3.0-2.1deepin1_loong64.deb
+    digest: 6d94ba45d894344f58e312c42a58b71905d46d094ccc7a9ea1648f84248e6f4d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-utils2_2.26-1deepin_loong64.deb
     digest: ef52f11025b52370deb6418d0431bedf9262d0bef31f66057666fb8648e2a172
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-utils3_3.1.1-1_loong64.deb
-    digest: ca9b23b73d8fee55c38b606c182b99e754018a05cbadddca9f7460287480ab7a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev-utils3_3.3.0-2.1deepin1_loong64.deb
+    digest: eb15da1b4298e2673d7d3f891da1dc7b59cbacbb313d0bc2ee6e2a06f7d3cd45
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev3_3.1.1-1_loong64.deb
-    digest: 066ae9c2bc8c824354b1fe1b067f4e0743997a0376f6076d7c748686179aefc1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libblockdev/libblockdev3_3.3.0-2.1deepin1_loong64.deb
+    digest: 71e83bc4ff3f56b7df0369214d2b4078a1619a9d4cc01472db91145d40a5227a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libbluray/libbluray2_1.3.4-1+rb2_loong64.deb
     digest: b28910a92aece870792abb3b969c20947e0a9dfeed0957b8207c49ef97766b8e
@@ -421,8 +424,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibc/libc6_2.38-6deepin13+rb1_loong64.deb
     digest: 4d25699d2b3054ff228cf4e83822adecfdbfebb848f2a9bd0786704ff915b6a1
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cairo/libcairo-gobject2_1.18.0-1_loong64.deb
+    digest: 0fd460a975ddc4f87d1704597adcd603ec099f338306d4ee1428e48b03ab7093
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cairo/libcairo2_1.18.0-1_loong64.deb
+    digest: 79927555f9e79d6b0f2e4b533853b67fea7cabb9f3fece9ff7a87684508222f1
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap-ng/libcap-ng0_0.8.4-2deepin1_loong64.deb
     digest: 8273873be5fb356e98e3200f0666ebc6a4568e46f6457f0e14acbf9d844d1a82
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2-bin_2.66-5_loong64.deb
+    digest: 0e334137263dbb4c2bbaa2aa6cab9bff8ad40125f2f7ed1dd562c6e4e6ec0ebc
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libcap2/libcap2_2.66-5_loong64.deb
     digest: d4cbe29713f415bd8679e79b2d4558a790c0749b1ee8f829ffa77cfc29695377
@@ -439,11 +451,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libc/libchardet/libchardet1_1.0.4-2deepin_loong64.deb
     digest: 6ea3ddf926ae9c78f550cc2a90add669d402bbc7fb930f80288ad85be6e215ff
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/chromaprint/libchromaprint1_1.5.1-4deepin0_loong64.deb
+    digest: 23c1612c4842c5ea3315b25e15d859301a5f925f439fc377b3b989d1473d142c
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cjson/libcjson1_1.7.18-3_loong64.deb
+    digest: 441206537dac908379f2e3512056745933ab830aadeccb3185a7349a3679f02a
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang-cpp17_17.0.6-5deepin5_loong64.deb
     digest: 8a7e85de84804dd73ec433de1ad3fb61905c8c8a943365620cea7cedd44a6967
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/llvm-toolchain-17/libclang1-17_17.0.6-5deepin5_loong64.deb
     digest: ee391e47845900e8362b9cc01aa298a4bf662e354f17a91d2cada946f72fbce3
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/codec2/libcodec2-0.9_0.9.2-4_loong64.deb
+    digest: ac3e8cf51f259f54509e48af947004af2066205eba950b11ef4eb1ffd898174d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libcom-err2_1.47.0-2deepin1_loong64.deb
     digest: 47f0cbde458a5b5998a470c7ccb6d7d299edda99007d79eede46b23ee2b26401
@@ -457,8 +478,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_loong64.deb
     digest: a9dcd576d5cd80ada64381a1727a3116545e93cf447f59c7414d1777e2993fec
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2_loong64.deb
-    digest: e1336bb3d22c37afc57bab108791e409f30c5333bdc7e01f2ac0f6d37735f2df
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2.1_loong64.deb
+    digest: 66c9628b7026bd09af0defc6c1ceae6fc5536260b55b7b2f652e3ef1b54e505d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_loong64.deb
     digest: c06121aeae9359ded8ff84c74ade5b03d1325b77c4a938fbd9931c8fe2caa84b
@@ -466,23 +487,32 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf0_2.41-6deepin7_loong64.deb
     digest: a594bca37501a18b322a46118883ed18bd99ef7d31eb5e5220a2d7c1adc4935d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin1_loong64.deb
-    digest: a6bcb173e61ad5273becf725933fff6bb10cfbe068d4a9a23af53b542b47cb78
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2-dev_2.4.2-5deepin2_loong64.deb
+    digest: 7452bfb8da2bf510f5095db334f7730c914a087571d313172392b1a2b12b986e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin1_loong64.deb
-    digest: f81c3066868743ee4c5cbf09088c1b7f8dfc38832b358012ebbeab92a1428051
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcups2_2.4.2-5deepin2_loong64.deb
+    digest: 2215b8b403b997e7ce667895f92cafeb22ceafcec9dd468c6583aa2dbe83393c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin1_loong64.deb
-    digest: 51248257d36d6528d3cf0cd7f038c6da2cf929267029b18a13ecdde2213cfb25
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2-dev_2.4.2-5deepin2_loong64.deb
+    digest: 07c0d38b655ad9e1dc4d93ca4a858255adb25dc7b131ae1509781b83f1d2d133
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin1_loong64.deb
-    digest: 3c9ca124f4de35b207d02b042d1d25bacff0d4a642e0c34ace340d4667e7c037
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cups/libcupsimage2_2.4.2-5deepin2_loong64.deb
+    digest: 054a65c1507942291091fe19cbb3ca046ab48e734b4e8a2a77939fa427a89363
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl3-gnutls_8.11.0-0deepin1_loong64.deb
     digest: 1e92b0e84256009fa0d4afa40bc765076fb97a45ab25e4f27b29a18a8b3445d6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/curl/libcurl4_8.11.0-0deepin1_loong64.deb
     digest: 8573cef0044bce90b3bef9f7219718c135f8856b079364f9ee962bb506598e4d
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdatrie/libdatrie1_0.2.13-2_loong64.deb
+    digest: 2babee650b0a341ed5e23cb131ae40d3c21ee46ecaad54fba79b764111628591
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dav1d/libdav1d6_1.2.1-2deepin1_loong64.deb
+    digest: 2aee3841500c6021eafb9bd0f6231ff1e814e73376d44b4a01d66b3cb6a1e358
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/davs2/libdavs2-16_1.7.1-1+dde_loong64.deb
+    digest: b5eb7f8d4bca07748ca52452a01a09aeb89013c49a6c8f72227aa4cf37f43195
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/db5.3/libdb5.3_5.3.28+dfsg1-0.8deepin0_loong64.deb
     digest: 976e0ae132630258702d76bc235bec36ea5820e506bc110585aee657fb487472
@@ -493,14 +523,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/libdconf1_0.40.0-2_loong64.deb
     digest: cc045f5e127c57d0e051177ce11347f3c46f20c345786f2082f6cf11ec00ff31
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.10.6_loong64.deb
-    digest: 8b7c1a6747194d740813699b2b0782300a5b2e80b799e219d4ee82a27e730385
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.69_loong64.deb
+    digest: a73ca733769e8fe8a2502d316aa003e7cadee73e9a2a30fdcded12532c69d795
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libde265/libde265-0_1.0.15-1_loong64.deb
+    digest: b074379f8e7ec81a299a83f504e0638be77e7d155d0141feeb31f4f5879042d1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cdebconf/libdebconfclient0_0.271_loong64.deb
     digest: 13dbf4cdea963eabe585bb8bbe3f16489cd990adb00cfcd870fcdfcba960a967
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-pdfium/libdeepin-pdfium_1.0.2+rb1_loong64.deb
-    digest: 00cb9cddfca53cc6c7a1b00480c1f5f4b9aa7342f75116c71c790555a1060ee2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-pdfium/libdeepin-pdfium_1.5.3_loong64.deb
+    digest: f2bb5d0d301092c0eec6c3833159723a4ffdabee6d47f0d55e1067b4d03f7278
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdeflate/libdeflate-dev_1.18-1_loong64.deb
     digest: 6d218959ede7fd5ad4fde3c25dc2c26f113d1e07c487d344a7678c29b9ce0dfa
@@ -511,44 +544,38 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_loong64.deb
     digest: f52242c7bc863bdf87fda9ef7accf1e12816999fb5dbfb590325399eace9052d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn-dev_1.3.4_loong64.deb
-    digest: 87f958d8e1275df925f92a67367628362bd4bb1073dd8bd7dab29057cadd99e0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.69_loong64.deb
+    digest: 18c4a3f00d1615e810949138112413ea545af9d86faf1c3feb8e3386e4ce68ef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-burn_1.3.4_loong64.deb
-    digest: 2d2bc896913621876755eab309730627bf7f992f42711e0ffde2cc34ca664683
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn-dev_1.3.31_loong64.deb
+    digest: 63861e5ca137e9df41b623f232e2277a212f327d1e5449b221acb3a5f01a434f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.10.6_loong64.deb
-    digest: 9c70a3d28a2cf1f7f95c9537982bbd4d0cc5dadc1b670836c947129f40449216
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.31_loong64.deb
+    digest: b63c0f0a42f69bffbc3bdbd8dc582197c3ed7a65a0b6ec4318d707c1000cce94
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io-dev_1.3.4_loong64.deb
-    digest: b6eef432a664c8e34ce81bd19936990c94e8843e790e486852d615037f72712c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io-dev_1.3.31_loong64.deb
+    digest: e864c289e3532245efd49c86a9f079ff461b10d836b4294b51e4ed0ba9d45c9b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-io_1.3.4_loong64.deb
-    digest: 05cba15aea4f5916dc671442b917413e0cd032c5c9b163c026acce08db43ab6a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.31_loong64.deb
+    digest: 41de45b216369423e366b00e474f09744d2be1ced1962b18c6f80f47c01719f6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount-dev_1.3.4_loong64.deb
-    digest: 0072251c611774a48852e0de97c2ebfc9323fbefbc18d6a26e9b2c6611aa3610
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.31_loong64.deb
+    digest: fc33f1b7f5a61ae0ec4974027bd04de69d9caa6d6c87a9929e69a7bc134d1e91
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm-mount_1.3.4_loong64.deb
-    digest: f21d91e9b1d2c1ac953b44bd9618fd3a5d2ce0e733d1b3c02c03f82b5a625b3f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.31_loong64.deb
+    digest: a15a3659223985691391508b4601580bc116864ec10c477dca9d6895287527ec
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.4_loong64.deb
-    digest: a547fd8fecdfd82971d870835dec038153644a49779fbec07cdff9906527e71f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-search_1.3.31_loong64.deb
+    digest: 7c43cfd5a1f30cbf17d6abad43de25069dee5e78cc20eab26baf0e6fa6b45350
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.4_loong64.deb
-    digest: 1176661391a4d283085cf917cc316dd1faf123448ac8546e5d105377db44f5f6
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.4_loong64.deb
-    digest: d4a198bc1f6fd6a26fe45a3ec3df9ede921e1b23a9812f9ae9ac5c8dacec8d23
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.10_loong64.deb
-    digest: f2beb1da0ae184a67feb67b7e86a49d48d453469a044bc12f27320aa35e71975
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.21_loong64.deb
+    digest: c6166a1302829b620c52971aa3ef838b6dfc675905b5a67e28771f5d71437a2b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/double-conversion/libdouble-conversion3_3.3.0-1_loong64.deb
     digest: 1cb1deef108f4163f884f564e9fcfd429adc315e9509c30ff3bcf936824ac543
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin3_all.deb
-    digest: 71989ccb16cfcc04aa5a86f06e4dff837a4fa755d04d17d5f0cf329fc09dda04
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/libdpkg-perl_1.22.6deepin4_all.deb
+    digest: 569373a35267f9cf2e8d0ee6d42c9047f50fa2174a0ac72fa77f494a0f0a9d1b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm-amdgpu1_2.4.123-1_loong64.deb
     digest: a26ef022dd15349da87ea50e9a8fa2799ab3f5287c93075bbf6c229c2eafd969
@@ -562,62 +589,50 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libdrm/libdrm2_2.4.123-1_loong64.deb
     digest: 9b28e3fcb6cff61e26352d3b426fe25b0c19961120d499fd5cb05f5177b411bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.25_loong64.deb
-    digest: 6c61509dbfa71c1bef66b405f76a18e4f68e62aed4d55626fb2fd2e2ac87c8cd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core-dev_6.0.38_loong64.deb
+    digest: 46b262c7a9142265d96ed03c896080b6be4931cd96881ee36d450593c1b23185
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.25_loong64.deb
-    digest: d637527e884ee0fdcf6683013c932de3230c7c357afc87a4d2e31e0250c76d84
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6core/libdtk6core_6.0.38_loong64.deb
+    digest: 2a051f11ab21c3eb73382db4cb96c892e5c25be60b9ec7b1c436645df09237c4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.25_loong64.deb
-    digest: 7a16c5c6e9f9002a14350ca92bcd645a7b2fa0f1dc2fdf0ccece81628e65e530
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui-dev_6.0.38_loong64.deb
+    digest: 5c820da0d98e49b0cafcce328abc7b20f79a57fe8e9955eab7c86232ca4d217c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.25_loong64.deb
-    digest: 4ae1e9b1b54e2c23bcb5d1bbe82d9e8914d86c8f6bd849e564a72cf0401d6e47
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6gui/libdtk6gui_6.0.38_loong64.deb
+    digest: 204e21dfba6edbcf36a22ffeb1317cfabed65d11eedb04cd53840dca04ba72ef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.2_loong64.deb
-    digest: faecf60fdd232fce51578eee0380bfebfccc84cf7c00ae3d41af9a43572f2c0d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log-dev_0.0.4_loong64.deb
+    digest: 85431680f43cb35350110f025ab764f817a87ef8b87f8aaf1221cf92324a22d3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.2_loong64.deb
-    digest: 9e03504ae093c9be1bec37e76dd97ef78bf4fe519320828ebb41096cebe47649
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6log/libdtk6log_0.0.4_loong64.deb
+    digest: 5dd93e358d83fad8b4f44962845e07554f43f36f252c886f694cf165ad67a3d2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.25_loong64.deb
-    digest: 55fe88c9f524afdbbb25ca361b1bb5d508848d94c9fcf8add1f9559ae717812a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget-dev_6.0.38_loong64.deb
+    digest: 17e369876960256cc74b9a89b79f507944aa3f1965f443fc7d6fdbebafb60ea6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.25_loong64.deb
-    digest: 81a053ed14e32a37af815860e1a3f77c06c00956dbe840040b25098335b4e1de
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtk6widget/libdtk6widget_6.0.38_loong64.deb
+    digest: 18fdea046e17f28b1ace921d4c27f8eeed9a28841c46824138307c9f47722cbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.5_loong64.deb
-    digest: a33416dbd875dda49e387dce675dfbfe364eef8c0237ed869714535deb97987d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkcommon-dev_5.7.18_loong64.deb
+    digest: 43b505fd21a6fe0c79ecd5c8140b1619d20bcd243d4d4576fb2c84c1644b85c1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcore/libdtkcore5_5.7.5_loong64.deb
-    digest: 5535d463111d197c4cf73a7de4820acad5f2221b536dec3420e266b1f3a23f67
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.18_loong64.deb
+    digest: fef371d4b3e03bf0e9ceb368698a63ac51243fe823d5d7bc19f1654836e5d81a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkcommon/libdtkdata_5.7.5_loong64.deb
-    digest: 7e6f8fa112dcfc39ddd784f68cb20629ac9fdf8a014035c4233fea7d3afeafc1
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkgui/libdtkgui5_5.7.5_loong64.deb
-    digest: 82709bdbd229ddff21899ed70fc00d520f8ebb5ea2f44e2e16421a2c9656a5f7
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtklog/libdtklog_0.0.2_loong64.deb
-    digest: 8fb52bbaa8b7e67ab7014d4a251a21adf61b57dbf6f926878324b76f453dd2b1
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dtkwidget/libdtkwidget5_5.7.5_loong64.deb
-    digest: c1bfd6954fa4498712c1299080e0610646452a3ee8d215c1b9a824efa7274e33
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/duktape/libduktape207_2.7.0-2_loong64.deb
+    digest: c46919dfca686178998927311123320eca3c995576736b5b4a0174f567289f13
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libedit/libedit2_3.1-20230828-1_loong64.deb
     digest: 851c5523af03e9dc081aa14afbeade7eeb1a21de5597226f13e0dcbed4a6ade7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin1_loong64.deb
-    digest: 3195c98434e274eb39ccd91f9afb6bed2c2ff6d3122d69d2e6bad9c1660efc4c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libegl-mesa0_24.3.0-1deepin4_loong64.deb
+    digest: 7877f5ac8d6ca3d585de64047278d3f6983e9213b31a3e2d4d8b03218474f4da
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1_loong64.deb
-    digest: bbc7f8773ad9b2cfa4a27a26d6ad4c276eada2db9b680d54bdf7eb59ee9e5012
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libegl1_1.7.0-1deepin1_loong64.deb
+    digest: e20c3e83c2e1e4d5787efcc5036312ebedbc4c0fedf0c2578ebb53041042e2e3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/elfutils/libelf1_0.191-1deepin2_loong64.deb
     digest: 16e47795eed490234214777685afc5c411a8ad0fdaf3508469e3105fb2b364df
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libencode-locale-perl/libencode-locale-perl_1.05-1.1_all.deb
-    digest: ef71d5b44ceef8015dbe954f6007f7d7fb32ceeafa49c8afc28ea8a79d4e9ad9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libevdev/libevdev2_1.12.0+dfsg-1_loong64.deb
     digest: f2f047f2363dda33826f748756c5b1c8a2bf809c981a66509876eb150583b278
@@ -625,11 +640,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libe/libexif/libexif12_0.6.23-1_loong64.deb
     digest: f5365c63e491f48204faef20665b2b513c10338425d3e9b68c88ca999c087f24
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.5.0-2_loong64.deb
-    digest: 0e5c956c6ba2967eb8e61479c2bf56189c8bee0077ded44015b9240ab11ae4f6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1-dev_2.7.1-1_loong64.deb
+    digest: b766ee38f67bcbe9afec078d8fb2f5fb273e35b506a1d1a3c135c5ff4482121c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.5.0-2_loong64.deb
-    digest: 845317fb7d0fdc029f3aa98c870826391b9bdb530c6aee296fd1671ed5dd8429
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/e/expat/libexpat1_2.7.1-1_loong64.deb
+    digest: 4b842b02c3c84ff64ef932b999fdc20e776a4f410cae4c065deed16e9ea5e99a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/e/e2fsprogs/libext2fs2_1.47.0-2deepin1_loong64.deb
     digest: c460fd2821af24b6a198979bfbda6c4cdbc31055c5e8d9837c5f0961d5b69dc5
@@ -643,17 +658,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libffi/libffi8_3.4.6-1_loong64.deb
     digest: e1d9a61065aea68e96e14f496d7bfd63e024f8874e1d320cb607efd82dd96910
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-basedir-perl/libfile-basedir-perl_0.09-1_all.deb
-    digest: 79f5ef747c15be92e24a1adeea98e3d4c01b1b90b730a184a8ca4959a1aa4684
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-desktopentry-perl/libfile-desktopentry-perl_0.22-2_all.deb
-    digest: 19ed7f791a824bd6525c02cc6011bbd614880f3408e78eff5e16e1e9990334a8
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-find-rule-perl/libfile-find-rule-perl_0.34-1_all.deb
     digest: 8ebc94473bf3381e34408415da523e390c2fb3be418f3c298deb6bc82373ded5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfile-mimeinfo-perl/libfile-mimeinfo-perl_0.30-1_all.deb
-    digest: 4d9cecdc4b82cee837e74512293b8c84a554d3cdf6c760627cd9c42d6c752b92
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/flac/libflac8_1.3.3-2_loong64.deb
     digest: 88b83d3414a7170f0e4ed2ba671b9cc45e5b376f3481a8154b094148a75f2fb3
@@ -679,11 +685,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/freetype/libfreetype6_2.13.2+dfsg-1_loong64.deb
     digest: ad56d47b6131633a5cd1f2a0e651c4bad65c92c35faf41e664ff79d9ca0df2c4
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fribidi/libfribidi0_1.0.8-2_loong64.deb
+    digest: 16a5f333df8d58b5b343a3ae40067a9b1132eb7f3cdf1517b8cb88da6d5b0463
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fuse/libfuse2_2.9.9.1-1_loong64.deb
     digest: 43e592f28f31cb7ccbdac7e371e6421922894680f17cb01590ac1f2f89b09782
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin1_loong64.deb
-    digest: 10e0a5e6a07c0b34a622d1464bf739af4e4be459be5cb6b8589673d5ad887413
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgbm1_24.3.0-1deepin4_loong64.deb
+    digest: cc93c2d61fc3c6a93ba49cd4c6fac1caa03a6c330dc1900a43bbe4e747fc7eda
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libgcc-s1_13.2.0-3deepin4_loong64.deb
     digest: 05d11e942b30ee6974be843ef2b8539426f3891c20bceb2e5bfc823e4c25b673
@@ -721,23 +730,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gdbm/libgdbm6_1.22-1_loong64.deb
     digest: 2d965b1e2624d262111a5a767278f4f4ad51eb1c073096ce2dbc42e0c02f3fcf
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gio-qt/libgio-qt_0.0.14_loong64.deb
-    digest: e94e105f834578d9bb2961bafd8726debeaa9ef501f2d2185d8b0f9f99a60d75
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gdk-pixbuf/libgdk-pixbuf-2.0-0_2.42.10+dfsg-3_loong64.deb
+    digest: 69e080182493af879fc8ea17ee6637a962e93a90bf26edbcb72ed4910d32e40e
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gdk-pixbuf/libgdk-pixbuf2.0-common_2.42.10+dfsg-3_all.deb
+    digest: bcf7a388b33a76d765b3db4dc10fc0a946086bc7409228898ffbcc522e9dffc9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libgirepository-2.0-0_2.80.1-1deepin1_loong64.deb
     digest: 02f892b6d38643410cd753637657b9803eb718268927eec5232e68045e81d13c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1_loong64.deb
-    digest: 34cc7650a8d538e59d44560580ff7d0819b2607877299a65585cb516d4136c03
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl-dev_1.7.0-1deepin1_loong64.deb
+    digest: 37a693f96d02d97be01c45d972836cbaaac0b9a5043174a04b2e2eeff251b30d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin1_loong64.deb
-    digest: f52657846cf6380d17182e22971638b9d1e617dd504dd345844f82cc34039101
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libgl1-mesa-dri_24.3.0-1deepin4_loong64.deb
+    digest: 45cb2d6de8f6e7c898ff76bdbd5255d630d1df174a8cd028d28dcf441bca009e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1_loong64.deb
-    digest: 623a88c159a1e9eafc6316e91d3c55179c692fa950ecdd06f1955144813eb6b6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libgl1_1.7.0-1deepin1_loong64.deb
+    digest: b6dc7a60ae6e3530a6caa3e45d5869603685c43ac8937535062fae0b5c8863ca
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin1_loong64.deb
-    digest: 8cdbd33fdcfe76829fde63f112026b1e9f6b08544c2a0d13bd37b7b059c37771
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglapi-mesa_24.3.0-1deepin4_loong64.deb
+    digest: 0fbe33c65fcd9f8d498846fc628c0fd65f86f0e8664618b83d325bad58b56a10
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glib2.0/libglib2.0-0_2.80.1-1deepin1_loong64.deb
     digest: 796a8a4bfcc14d204bc23914f524a0dcb3b0545611060b3056547eb281e277f4
@@ -757,17 +769,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/glibmm2.4/libglibmm-2.4-1v5_2.66.6-1deepin1+rb1_loong64.deb
     digest: dc9010230b12a76fbfc87155e7b80f9f00a3da819bf9380304f35e3d3ac43035
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1_loong64.deb
-    digest: 4ac20b2ddbc5d3985d95befa3db331ebcf6bf9d8b9c13df462018e2e6fd91218
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglvnd0_1.7.0-1deepin1_loong64.deb
+    digest: b3763b7b1910d2692fe39f0b76195b639acf92ea656d4ff61da867393422251f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1_loong64.deb
-    digest: bdb1eb7fd4e391c38fc5a21da29b1569afb19bf9594e46fef10311bd4d4f0441
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx-dev_1.7.0-1deepin1_loong64.deb
+    digest: 260b85824035f054f7e25e2b142ee5397c28953f77f463276203b0e5ed8d9bde
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin1_loong64.deb
-    digest: a54db44910df509a4b4b03466fae1d5118f27264cf0789dd638f04b2bbf65245
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/libglx-mesa0_24.3.0-1deepin4_loong64.deb
+    digest: b219b07aeb0e70c94dcf3d2161fdbe5478a745b9bf8b660ef6cb8155f1e81e09
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1_loong64.deb
-    digest: 51e7ebb3d6b78cc5f420d864eb898e91a1ab386fea5c51548439231aa66d8232
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libglx0_1.7.0-1deepin1_loong64.deb
+    digest: 8b29582e04b7987e1b45b1e7229eb4b772bf6d8ba18b5499b22144108aa2b70a
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/game-music-emu/libgme0_0.6.3.2-7deepin_loong64.deb
+    digest: 03512d70fb50bc97266e9f14dd56fc5577d455aed40072f0f2794056bdd6ac28
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gmp/libgmp10_6.3.0+dfsg-2deepin0_loong64.deb
     digest: c09ccc302996ba01e2f836ad038b25f5039c750fe2e10bbf66154f65b4ab3e5d
@@ -802,11 +817,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/graphite2/libgraphite2-3_1.3.14-2_loong64.deb
     digest: 3fc95b46c6dc87a3991386255c381d00c68a6ae6bfb4390ccb05f8cc61949331
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gsettings-qt/libgsettings-qt1_1.0.0-2deepin1_loong64.deb
-    digest: 647d808660c8505811549a3570779473f66835b8611aa76444fe8ea69fed043e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libgsm/libgsm1_1.0.18-2_loong64.deb
+    digest: 3dc3d3c042ca69e0382907caf9578f0992a109e3e47394ae59359d4183b915e6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libgssapi-krb5-2_1.20.1-5_loong64.deb
     digest: a74abdb1e7ddf88624513747e6591d1c799bc8774187470bd05d8d489834d596
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gst-plugins-base1.0/libgstreamer-gl1.0-0_1.24.6-1_loong64.deb
+    digest: fdeec611d25b27a7474597c7de734151bb846244170573160c521f64e4d4ad72
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gst-plugins-base1.0/libgstreamer-plugins-base1.0-0_1.24.6-1_loong64.deb
+    digest: 02d440bdac148bb713d855f8e4d959540efd876991e4b2097f0235cc79a38a01
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gstreamer1.0/libgstreamer1.0-0_1.24.6-1_loong64.deb
+    digest: 50cd1bd862ba5966603eab9fd1c299990d77177fda102d5e4d3e731d82e5e7b5
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/googletest/libgtest-dev_1.12.1-0.2_loong64.deb
     digest: 77c8bbccdff33eb6584b8ddda01e2eb693cc36963ef00f4c16102ae2763cd458
@@ -820,8 +844,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/h/harfbuzz/libharfbuzz0b_8.0.1-1+rb1_loong64.deb
     digest: 23f39df88cbc47f74e5a77408b2cdbc4fc47e41fdae3e5fb319a9cbe552c12a3
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif-plugin-aomdec_1.18.1-1deepin0_loong64.deb
+    digest: 736b44df235293ac013dfb665551c70a43bd0bafff7f4d2544494c3fd88614b4
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif-plugin-dav1d_1.18.1-1deepin0_loong64.deb
+    digest: 6b448f86579c9439a4f77f1d821b21ae69913128f5d75c71d9e86cb3eaa8d8a0
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif-plugin-libde265_1.18.1-1deepin0_loong64.deb
+    digest: 6a73e15d6663ee7ca1c62c5822d93fb7015ba0a4e1bd55e14179b3226c3db184
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libh/libheif/libheif1_1.18.1-1deepin0_loong64.deb
+    digest: 330186df0b59f153887c1763a5a2a873458e268316f1f38cd2cccf1a41d3a943
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nettle/libhogweed6_3.7.3-1_loong64.deb
     digest: fca8fa6138c16bfb7f8d8fb78f55799c24b9a01bbac0202816b22624cdd0da6a
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/h/highway/libhwy1_1.0.7-8_loong64.deb
+    digest: 831d45c39ca2bf93b17d7f6631cc4d3b6ef1dde879911a3fb55953fa73719fdf
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_loong64.deb
     digest: 71f07175fac63f8a51f001299a9329a38c4320df6b46e6bdda20768aa90a3456
@@ -840,9 +879,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libinput/libinput10_1.26.0-1deepin3_loong64.deb
     digest: f8251fc25fdbcef6b938b6be532237f63c3dff78dd83b1d3ff665748685f7f4b
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libipc-system-simple-perl/libipc-system-simple-perl_1.30-1_all.deb
-    digest: a528ecfa70fd8f3b4cc024947ff264e3952b0245be9a7147e556d8e1a037007c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libisoburn/libisoburn-dev_1.5.4-2_loong64.deb
     digest: 67c9f8a3e99fe87526fabc5eb425d8ec586e4e0cee152648fe32ac1e066b6f0d
@@ -886,17 +922,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jigit/libjte2_1.22-3_loong64.deb
     digest: bfd1511b2382ac1448b1e03e4712e09be85eb8f7e3c09696590dbe6d78a176cc
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/j/jpeg-xl/libjxl0.7_0.7.0-10.2deepin0_loong64.deb
+    digest: ff74443d44dd44adb4aba8829d58bb89ad9bc7bcb934b5bd7f7b578fc86b9f73
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/krb5/libk5crypto3_1.20.1-5_loong64.deb
     digest: 4a83826bbb0da645b6f48c1de0682bd7ba1d61a2b903fed7738ec7c88f559b8b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/keyutils/libkeyutils1_1.6.3-3.1_loong64.deb
     digest: 0f7646fd6ba7bcf29756eac9b72ce2b03ad5de6d90e131ce0ab97e51f1da29ab
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kcodecs/libkf5codecs-data_5.115.0-2_all.deb
-    digest: ea3e2873fa4d0e0fe356c8de8a93d0dba6dcb38ac53f215a4bce4cda28d63fe9
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kcodecs/libkf5codecs5_5.115.0-2_loong64.deb
-    digest: ef2de161e57a175d3602e62115c9fded3b55142274accaffbbea5d5fbdddf97c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/k/kmod/libkmod2_30+20230601-2.1_loong64.deb
     digest: 500ef5f0d6bfa0ee386b8300bf8f4daf6ca984e2d3866e16c91affc006d82f31
@@ -940,11 +973,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtool/libltdl7_2.4.7-7deepin1_loong64.deb
     digest: 784f3bc14c028381795abac2f06af4dc8f18aca57638bcc6d9624b34efc0fc4a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++-contrib0v5_3.0.8-deepin1+rb2_loong64.deb
-    digest: de923e05de71fe5303a0864ead754d3c2390f17b7a1250063d4ace3fb616810d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++-contrib0v5_3.0.8-deepin2_loong64.deb
+    digest: e0c599f2788c4cdfcd9d02eb6696052acc8766335b8ea4dd2811309ab458fc60
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++0v5_3.0.8-deepin1+rb2_loong64.deb
-    digest: f6407ecdf7445990b77f60e12d42121f3acef746de9ab93be396df665b4ae9f1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lucene++/liblucene++0v5_3.0.8-deepin2_loong64.deb
+    digest: d3cb1028c23ded95ac629303967cbeebe121737d27ecb52e571f925de09ab003
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lz4/liblz4-1_1.9.3-deepin_loong64.deb
     digest: 223608f8e5ab70c862665634392467d8cdb27b39d749f8367ecf8f709ffd0044
@@ -960,6 +993,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/file/libmagic1_5.45-2_loong64.deb
     digest: 56329f9b8dcb4983a96465b3d78fd4ab2191da4b7c88caa47d59ed0ab3a8fba8
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mbedtls/libmbedcrypto3_2.16.9-0.1_loong64.deb
+    digest: 8179fb6587d2de06e44f88785a1a3a530b8b8317d17c0dd4a4878505f6eb30cf
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libm/libmd/libmd0_1.0.4-1_loong64.deb
     digest: f54d26b7c46c848e15a460cd03140e8a436ea2f5b6b7e287e47994d1c627dbc8
@@ -982,8 +1018,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libmount1_2.40.4-3deepin4_loong64.deb
     digest: 31a69b95233506e4afc628618c8fc0b9ca0c1cd0b69f97ee83e6bc5f7c17f6c3
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lame/libmp3lame0_3.100-6_loong64.deb
+    digest: 4a2df6ca32a6a40ac918843adb284bb0929ae321f2c3dd269e40749d542af562
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mpfr4/libmpfr6_4.2.1-1_loong64.deb
     digest: 441bc4890aef4c3f38181d961d98e571892f2f32a2ba38b27323d36cd26c233b
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mpg123/libmpg123-0_1.32.8-1deepin1_loong64.deb
+    digest: f03a7545dff01e921e9dbcb683464188c28cd289d557af0778efbb9962f93db2
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/msgraph/libmsgraph-0-1_0.2.3-1_loong64.deb
     digest: d2ad2d34d2bb171363cdbe11604e73d65b5d1087e19db4801880bac82f978fb8
@@ -1018,6 +1060,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.6.0-1_loong64.deb
     digest: 87540ce4f8f6865f114b3153ebcb0f623a912010d3cf1e361714e6489260c9ca
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/norm/libnorm1_1.5.9+dfsg-2_loong64.deb
+    digest: b8ccd5bf943ded55cccdc92d59c8abb35a1fb65fc3425ebe35670d37b7bdad6f
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/npth/libnpth0_1.6-3_loong64.deb
     digest: 65cc76d2ce6fc32760d615dae94978c76979ac5754d888a5366eff81de454157
   - kind: file
@@ -1042,17 +1087,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libo/libogg/libogg0_1.3.5-3_loong64.deb
     digest: 45f908be81e813e6326426acd4c5675adac085383a93bf5b87bee2942a2152bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1_loong64.deb
-    digest: 72259f4ed0b1127c554e3747b8763fc18659dc5178fc2fe32ada313357c1802a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl-dev_1.7.0-1deepin1_loong64.deb
+    digest: cd4ffaeb85402fdee4cd618e5d95b20857b2eb83f25d6109f8026b714b4af470
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1_loong64.deb
-    digest: c912f8a5180cda07f485be9334b8ca0c1bf779bc2449ec5fa08c347e5f18a132
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libg/libglvnd/libopengl0_1.7.0-1deepin1_loong64.deb
+    digest: 5ce97ab48242d9a6440c70f71408b84db1d2417a4e61007e08dfc3f748d1c4c9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openjpeg2/libopenjp2-7_2.5.0-2_loong64.deb
     digest: 575da3427fe1632f4dde973fd2cf3b4a15dac1a77d612bedebeae18d1968095e
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libo/libopenmpt/libopenmpt0_0.5.13-1deepin0_loong64.deb
+    digest: d5f7b919880e85ef999377610d15bc712151a6ae5b5aaf9752cc59d21923992f
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/o/opus/libopus0_1.3.1-3_loong64.deb
     digest: 49e4f3ab950054084d1cbdfe848f0dfa73c4ae0f8ceabe0a6987c522a26e3765
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/orc/liborc-0.4-0_0.4.32-2_loong64.deb
+    digest: 7766214e53b7df98494abdb571e257b5d0a4dbd23fb8f4e2e216ec9278503175
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/p11-kit/libp11-kit0_0.25.5-2_loong64.deb
     digest: 75dc180effd2912fd0a127952cc27c52ff0e900d7c8b79f3bb4b0d1ac1a120e3
@@ -1066,11 +1117,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pam/libpam-runtime_1.5.3-7_all.deb
     digest: 28a2789917401d06fff5c31991bf27fc808626c5c086219df63cfe1acf978b97
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libpam-systemd_255.2-4deepin6_loong64.deb
-    digest: 0a194d4268e3057bd4cec4f8752c5dd979f3283db743319515e4ba2aa3bd03e1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libpam-systemd_255.2-4deepin11_loong64.deb
+    digest: f852c4a84aae7e2c86b24936ea0984744f9d1d558c715e3451ebe3957e23c6dc
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pam/libpam0g_1.5.3-7_loong64.deb
     digest: 2bd2b109cdeda454a9d61ee61d06e9c39a1ef0296d891f40549c44dfcb0573ca
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pango1.0/libpango-1.0-0_1.52.2+ds-1_loong64.deb
+    digest: c1e53075721790fad6dadb0f0c6f85da39b2e127374424a63ac010d4d7972f74
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pango1.0/libpangocairo-1.0-0_1.52.2+ds-1_loong64.deb
+    digest: 145fc9b1b4e85cca2d15a606d73ad0fdaadfd2c16d23afa399ea2d9f68cb09b3
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pango1.0/libpangoft2-1.0-0_1.52.2+ds-1_loong64.deb
+    digest: 5d476421c3f46fc235e62292a437b6320e9f8cad252f6277a3c607faa5095afa
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/parted/libparted2_3.4-deepin_loong64.deb
     digest: 0ccd99080a96bc93aae816322c088225c409d1cbfad298ba82bca0a2298278c5
@@ -1090,11 +1150,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre2/libpcre2-posix3_10.39-2_loong64.deb
     digest: efb78bfaecc447039df6ceaf21a40055d692ceea4a38e700e280dfd05c521881
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pcre3/libpcre3_8.39-13deepin0_loong64.deb
-    digest: d301118058e8ef3637d4710e3155b0700e1d372546d412a6fde28d3c0326c6a9
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/perl/libperl5.36_5.36.0-10deepin1_loong64.deb
     digest: dc6587b5ad4bb6a51f30edd225d1aa4d0f2e5c24107aeaa8bdb41e13f2136fd5
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpgm/libpgm-5.3-0_5.3.128~dfsg-2_loong64.deb
+    digest: 9b68dc19b458a678ae21f5eec1f27f011f0c8da502cf3cf234b5cf4f8e2b093d
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pixman/libpixman-1-0_0.42.2-1_loong64.deb
+    digest: 0b76c37a85a00b26233f17a3cc0e4459649ba286528614f121767c9b82c4d3a7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/libpkgconf3_1.8.1-4_loong64.deb
     digest: 7fa4ed870a512323dc2bdebb32e85ab5c08036153b042a932beec468b3ba6089
@@ -1108,14 +1171,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpng1.6/libpng16-16_1.6.45-1deepin1_loong64.deb
     digest: 711fc166523e536c981def0bc709970f34be02ed60226bc129d2b1911b4ac46a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin6_loong64.deb
-    digest: acc908348a6839f22e8e4076c42900542a180ffef9e331b4a93631164329431c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-agent-1-0_123-3deepin7_loong64.deb
+    digest: abb634edd336c74e93bb9112ac7fe218e7375d824deb0d9eab295bfae60c9708
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin6_loong64.deb
-    digest: 313bab65ae23545d7eaf34d2d0cc5321bc3d51e7d46ad1aeb63bf45b9ddd7c24
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/policykit-1/libpolkit-gobject-1-0_123-3deepin7_loong64.deb
+    digest: 75d55921f9e8cb11b3f474a947dba74198b19a04b86aa6aa6b62f89c30b19458
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt5-1-1_0.200.0-4deepin1_loong64.deb
-    digest: df56466410622da67e80643cb7071bc04278d3428c40e1cc394b33d4528774ff
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/polkit-qt-1/libpolkit-qt6-1-1_0.200.0-4deepin2_loong64.deb
+    digest: 0892fa9207d0dcfd56074ed5889e0d37c8b9d8ae33c091cc21175ed6ae54d207
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/poppler/libpoppler-cpp0v5_22.12.0-2_loong64.deb
     digest: ec09442a862a14bd932bdabc2c8522c4a69fead3194fd44991271626711be7de
@@ -1126,8 +1189,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/popt/libpopt0_1.18-3_loong64.deb
     digest: a14418f1d0093f495a76c279cc86351c481d28fb2b6c920a217622c2ea6a6a4e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.4.18-1.2deepin0_loong64.deb
-    digest: 8c5d37ea50aeb08f936ee1e57b5f295cbc5d76690d92c265b26fbf0e14e687c6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_loong64.deb
+    digest: 450c63cece1053b61ad1db303e20cf3008cd130f59907df2610dee985a1ac250
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libpsl/libpsl5_0.21.0-1.2_loong64.deb
     digest: 48076d0b45bdee001ab7b435296ab05853ab64402092af005e07437dcc838640
@@ -1138,77 +1201,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pugixml/libpugixml1v5_1.12.1-1_loong64.deb
     digest: c0b1583229b0598d53f538621d5664f544240877b106c0236906a51089bfbdb8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse-mainloop-glib0_17.0+dfsg1-2deepin1_loong64.deb
-    digest: 7f62038322d009f88b109e852c05c713884fb60bc6e41130a855bea60a2e862e
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pulseaudio/libpulse0_17.0+dfsg1-2deepin1_loong64.deb
     digest: f88e6830b6c1c94a8c0c337d6f79ebb19c2bddf0eaac23be7a0c15fce8e833b0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/libpython3-stdlib_3.12.1-1deepin1_loong64.deb
     digest: fccfbd0ff96d62aa2476f942b4e819b2bdce28f714ea360e036da7a0b3732597
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.4-0deepin1_loong64.deb
-    digest: 759e427492a789316db477eb515bcf7c94f688f88e5ed2cbb5da033a06b33966
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-minimal_3.12.11-0deepin1_loong64.deb
+    digest: 1d472fc15c2ee3bd55b69219903a7ff8fb6a5b880cfc1f2506c8ebb459f9b0f7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.4-0deepin1_loong64.deb
-    digest: 86f63bfe267ae688785e96f5671516a53846e3459ff9ca54a4896f83968990e7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/libpython3.12-stdlib_3.12.11-0deepin1_loong64.deb
+    digest: 86eda0624899d0be7965e8bf0b2189986b67daa8d280ff596e736b50bc1bc4e5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5concurrent5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: c7f95d6cf667ef1f72d5578ab19dac529759f91b8a3498899b3a26470d39f314
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 27f9e657d136a934f173a715d878d3d055b4f380e81fbabc76aacb44b6fc94c9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5core5a_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: 5f41ab472678cfac09bca24a1d116bebb94d93710e266d8821f7f044d4aeabc3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 1523b859d621d9a86bca84826591ec2ca94247e2529e9c3a407fba06593552fa
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5dbus5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: 19e395796ffca5cca8385d856c72c3f7163a6d3b2edd4ef4d25ec4fbac1a99f3
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5gui5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: 2a14b68dc73329968f75d54928ff652ca815774a35ea5eb1691f15482034ac6e
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtmultimedia-opensource-src/libqt5multimedia5_5.15.8-1+dde_loong64.deb
-    digest: 6f20e01acd7c8c38dbf2ebcc7c26be839b388f905089d10b3532f2b15ad719cd
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5network5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: a8f7337ba23af9032d15c212aae7b3e0582250741a4221c14a98c5b8648fd3e3
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5printsupport5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: e6a00175bcd3a6e2bf8606e72d745a9ce4829fa68e41c3f10b5acafce83b6c8d
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5sql5-sqlite_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: 099e43c0e2906c0daf5d62de4b0a201e7e9b66868cdcfe77b9b2d040f25972e5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5sql5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: 3e075553b6bb795a3033f4aff4b09923375b94a89f251b8cc263d2aa6cb9bd30
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtsvg-opensource-src/libqt5svg5_5.15.8-1+dde_loong64.deb
-    digest: a8c31a39d839b2e539f9c5d4afc1868da75e4feb23ede59a6eabad86aafb2d8d
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtwayland-opensource-src/libqt5waylandclient5_5.15.8-1+dde_loong64.deb
-    digest: ef0172ab855d5d9b84d798a11914f449525967d8bfc50841080f47d87e2f89bc
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5widgets5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: b2ba5a6592ceecf92c9826e9310ff4cea5db5b1fa488ec8adb14349c8c2d03b0
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtx11extras-opensource-src/libqt5x11extras5_5.15.8-1+dde_loong64.deb
-    digest: 47c680c27f798d0a752a38f567f6b7150ce55dd187438c07b1dcd8ca1b6c6969
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libq/libqtxdg/libqt5xdg3_3.12.0-1deepin1+rb1_loong64.deb
-    digest: 404791b9e35d4afc85108df579844bff613424738bd1912d3836cd023352e8ba
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libq/libqtxdg/libqt5xdgiconloader3_3.12.0-1deepin1+rb1_loong64.deb
-    digest: c35fe9acefd9b383ddabba0e556eba33d9e7ec79f87ef3e95637185877ee7c2e
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtbase-opensource-src/libqt5xml5_5.15.8-1+deepin9+rb1_loong64.deb
-    digest: f45d4ba91c40379ac1cc73ca3b2ec004d11cc5f4737da6bed7d4aa91dfdc0c61
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6concurrent6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: df1fb644c6f18c557df389f7c8caccb8041cdbcbb3ba64cc4bdf5bd9dfcf95f3
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6core6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 05d37808475216a0a62fb277a78a21045f6a3371c9771eb614a38e175c67d861
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: b4bf3ee86fcbc0055e09cddc5cf75dadf7f2d92f2991207c6a0c591d9ddcf3cd
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6dbus6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 51e1362bb514f7878aff724ed92035df7451ef96fe7de71c4452057340d8d867
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designer6_6.8.0-0deepin3_loong64.deb
     digest: eefebd3f3d07b0f7d2f89e0ba469128aba20e0a1093ee0cc1853c3ddbdfa8616
@@ -1216,23 +1228,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6designercomponents6_6.8.0-0deepin3_loong64.deb
     digest: 0cb93130f4822644f809425794909492760cee0cc6c3d5596883a07edfbf9993
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 6512d39f8b25de932f919e8c1c5f6819ca71277f4c8a2ce5590ae347b98ca552
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6gui6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 0eb4ed0089c77f53f38c49e30098727c78489b0d390a2ced33cba5de167aa5f9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6help6_6.8.0-0deepin3_loong64.deb
     digest: f748a917685218c990c97766bd2e9cf73caea758ba095bde0c76aed5d8b2c14f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 32d4331abcf04409ac6526eb631f53c4d4d78e4c284441f6f22a468f17290dca
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-multimedia/libqt6multimedia6_6.8.0-0deepin_loong64.deb
+    digest: 50cfc130b9f7bbc24dc0eee4ad75bd15dff40b9f126942ec1010f6e85955e112
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: a3d00166167d5a06e1fbb75780ca2965eb064eee915591358584a7feef57968b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6network6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 734dbb8e7e72a7e29fdcafa4d17f6dd1f2385c738b075858d68f3e7c06a8c8d9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 51d746486ddd8b214d7078de53fcc35701972f22cafd0248368176e06b80ea10
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6opengl6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: ce9b72f2477ff977aa84f328fed1bb4f74f1eeb63487bce88634bd2ae819fcdc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: c2cd48cbfdef345b85b35d08ada160aa696a1b23afe9f9a224ad2fd9ba7c17ec
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6openglwidgets6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 1756c764caeabe3b193dfd61c1d9f8f78e5cd8e63421c1c2e6c6c4d2adf00a20
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6printsupport6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 6321e7ffab0c4908deb4c93b1ea695b9a8e001c3f15cdb1e83af3be2dec5d072
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6qml6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 31feabbf3ad584c4c450c37b5abb61ee289e05b11bbf04533131075201387b35
@@ -1252,11 +1267,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/libqt6quickwidgets6_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 889af35681f2708a99b089a4c9aa5f22e487da2125af9132d3f0e7b579b408fd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: ac8528c19b56097b2476dce90edd35521971fab57e90fac1e44545866acf2e00
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6-sqlite_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 017f06d3ed3ed61c79b1305c5143cc23741d512d7e5bed5bb8afdf5409f9dd53
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 34291f35a8454f65214fa6ae65d31569edb74d581aed75bd502885f575e20915
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6sql6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: f8f3e1362f96ce18bbf6ab415b4fca82bf4f057b122c26dc956f3f0bfbc3e571
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svg6_6.8.0-0deepin1_loong64.deb
     digest: fc8cb023930b048f2caa531b913d991b4690a9f4692a9e4fbb423618ec67121b
@@ -1264,8 +1279,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/libqt6svgwidgets6_6.8.0-0deepin1_loong64.deb
     digest: 7a0239be93289e6b8d54806f5ffec75a9f4aea7cee0af219fc1932e64abde72e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 11eea51f1f01f37a4fecad877eaef15584bfd9792fa5cb6ed74bed8dce2119e2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6test6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 13e6c88915bb0c09c85a950bd41a150ecbab7b6bbac87d72900b3484e217055f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/libqt6uitools6_6.8.0-0deepin3_loong64.deb
     digest: a4651ca09a7927998b556155807a65a4b68d19a83f8a3a0907e4129f0ed983a3
@@ -1273,14 +1288,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-wayland/libqt6waylandclient6_6.8.0-0deepin7_loong64.deb
     digest: 7637f2f08e271e14a5b05007e2fd18a8facc2c6fc3f29fe1ba5e2c5ea0d037c2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: d3aa28809160e26462914fc87cd6b4fcb84bb59c9a925d864811c0fc8ab4a1d1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6widgets6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 0904fa02b80b91fcce261f02f8aeeacbcb2e166edfc9fbb8e9804639c22e6a56
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 26a96679e3356a3214126b3f58b1c6a2cd448f955925733340fe6fc1627ca7b9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/libqt6xml6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 529b35f3c63e834096085de61a2494f89aeb2103b184d5d8bf2e5035e60340aa
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librabbitmq/librabbitmq4_0.11.0-1_loong64.deb
+    digest: bfc60cbd6ee84fd4a6ee2d1002c27389d58dd451f8ec8bfde0e74fc8dbcfbbf4
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rust-rav1e/librav1e0_0.6.6-3_loong64.deb
+    digest: 1e6853c1d99619004034edd20102899b5896035984ed273409bf107d39139d94
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/r/readline/libreadline8_8.2-3_loong64.deb
     digest: a1c114f0856366970ce731783250b16f1a600a917ac54eb45b3fc765a7dc5e8d
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librist/librist4_0.2.7+dfsg-1_loong64.deb
+    digest: 14d4514b719515758c011e60486cdd4b3e652f1d556375f5e21a3e9029766874
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libr/librsvg/librsvg2-2_2.58.0+dfsg-1_loong64.deb
+    digest: fd93daa92c7be19210c417596d4c9213d3c734eb2ccaa2de3244fb40b1deb1e9
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-deepin1_loong64.deb
     digest: 8809a7bd4cd047bccc1e7198bfb8e154716a647cc619ac7d49cbde13b7ebcb1b
@@ -1333,6 +1360,9 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libsharpyuv0_1.3.2-0.2_loong64.deb
     digest: ee12b9b2406d779965c510510bd32f01ab931f62eea583bc206c1d41f4a0711c
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shine/libshine3_3.1.1-2_loong64.deb
+    digest: 83ec46f7ce2381f484401aa33d7540cfd954f5064ab2c3372ba55f67c9204b8a
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsigc++-2.0/libsigc++-2.0-0v5_2.10.8-1_loong64.deb
     digest: 7cb27db102077bd3d37b2e74a3f35b485a183c47a71141c9e0bf2add7a519488
   - kind: file
@@ -1345,14 +1375,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/samba/libsmbclient_4.19.5+dfsg-1deepin1_loong64.deb
     digest: 52e4ac1718b16731896e28d0791041765226b996b5519833b142470f3f12eae5
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/snappy/libsnappy1v5_1.2.1-1_loong64.deb
+    digest: 037f2de80f65e4491772282c5c45bc286cca8a804f4141f55bd146b1dba20ccc
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsndfile/libsndfile1_1.0.31-2_loong64.deb
     digest: 1724af768ad3f06d2bd8533b94e1327ef2ebe725405744cd510620afaec64a7f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-0_3.4.3-1_loong64.deb
-    digest: df3d8356aabb2cf1c24733e9e3410babc7948e3bbfa71a79269523d5502131c4
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsodium/libsodium23_1.0.18-1_loong64.deb
+    digest: 967fe90420e1c2608209f23f3a959adc2a3395203139559ef52a957bde15123a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-common_3.4.3-1_all.deb
-    digest: 1591543d840396ea47f24a2b3287dabc0a50eeb085e07f0807cd99a4ca992f13
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-0_3.6.5-1_loong64.deb
+    digest: 99667f001ab2ad04e0bf34d1ad63dd814d56c1526bc2d46b0c355677384ce4b7
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup3/libsoup-3.0-common_3.6.5-1_all.deb
+    digest: 1ea79c817fec9cdbea2a333656efe9898ed4a7492018321c6b8a1a12a013ae35
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup2.4/libsoup2.4-1_2.74.2-3_loong64.deb
     digest: 51b25b1a72b04430a39b95d366ed01a67dd658d95dc08a5ba84145b57dda9692
@@ -1360,17 +1396,29 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoup2.4/libsoup2.4-common_2.74.2-3_all.deb
     digest: fc72410b0df9a55ad859968f420c15380eb1c5b1a02e2ce71a541a28765f6a14
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libsoxr/libsoxr0_0.1.3-4_loong64.deb
+    digest: bb803883ea5a502ae59c3ee986680ce3612863406469d327009684d7377b27cc
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/spdlog/libspdlog1.12_1.12.0+ds-2_loong64.deb
     digest: 760ec85164e31b757b0e46274b5a1eafe5a6ce53ccd0e1c4c1d7e5338e93c31e
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/speex/libspeex1_1.2.1-2_loong64.deb
+    digest: 7f1a740deb7ae14c28a109d35664b0af52ed580d5c66fddda97c5d8863767760
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sqlite3/libsqlite3-0_3.46.1-1_loong64.deb
     digest: 7b26d965fb478c5ae7993ed753ffbb881ad0632063875a8c68585b56a7c70ee7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.10.0-2_loong64.deb
-    digest: ce3f0c9a9533ec1f20259fb9e851dcaf3bd4ff8788e68b3f7a3da378814b0f30
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
+    digest: dea4a89cee5d7d70b6143ef55501595bfa963aee8777e0f1b10f46a78dc9e578
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin1_loong64.deb
-    digest: 50a0de1226846d5adabf640c91d6fcd777d1feba9fd67e7c1cccf6013b62d0b8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_loong64.deb
+    digest: 55cc8ef205639767d2c5162b6424297d7866b3d77be3ec600b70ddf3345cd6d9
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_loong64.deb
+    digest: bb45ae77a9bd5170e8616a550c54e2c419435abce629ade62605dcf0aa544d11
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/openssl/libssl3_3.2.4-0deepin2_loong64.deb
+    digest: 0ecb05782da1c411a407535eb0fe4a9118a0b635cf5577b496fc0698aa1f70fe
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/startup-notification/libstartup-notification0_0.12-deepin1_loong64.deb
     digest: d5528cf8ef1dcf19b1b3245d894851bbddc35132ef3fd22e8c399fd5af91a514
@@ -1378,11 +1426,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gcc-13/libstdc++6_13.2.0-3deepin4_loong64.deb
     digest: 35e491e460731f9dd6e054429c576a0cef5fca817c034943b0463e6cf8503db3
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd-shared_255.2-4deepin6_loong64.deb
-    digest: e0bb61ab8dc47e418249ba2b5c1ea02cc517680efb5abe47ff2244b9e882872a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_loong64.deb
+    digest: d402b79e3fbfa42586f89b0b86c376772ec033ff6252032e0ea7edb831a9bf2d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin6_loong64.deb
-    digest: 1001ece64a54d675835700a91c8b99228f766e3388c192f81d19c179df1ea601
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin2_loong64.deb
+    digest: 62165ae4da8e988e34843872acc420a44bcc4dd65c725bec9012e3dbc97383e7
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin2_loong64.deb
+    digest: cdc134708e57d8d48bfc3379da2ae325de64d2409ec5c2217abe303f3c3d0554
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd-shared_255.2-4deepin11_loong64.deb
+    digest: 0c01dcf425021825701db5f5dca0601bde53e63fc69b547ee6132bd8d0431e7f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_loong64.deb
+    digest: 2e66a084ee5197d6ca309c766a7fb0d9a4b397359e21a5b7a920dce4695cfcf4
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_loong64.deb
     digest: d2688537a91f78d0b816045d583542bd5bb41bf4ef6e10d49672f4bbcf639997
@@ -1404,6 +1461,15 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtext-glob-perl/libtext-glob-perl_0.11-2_all.deb
     digest: 2e8cf563b486b56b4c875db16a37e5e24168085510b8bfd167efc8367cdcad1f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libthai/libthai-data_0.1.29-1_all.deb
+    digest: 3a87af58b0b3becac7062da11264d083cd68190e7dd421c2cbd00da8841cfa25
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libthai/libthai0_0.1.29-1_loong64.deb
+    digest: f870e0bd959b21558d99b2e89c1dd637b8eab46382616482a7eec19df681978f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libt/libtheora/libtheora0_1.1.1+dfsg.1-15_loong64.deb
+    digest: 490265a0c220145d4a1552c50a9fe1d580a70f56db7eee7e2c609bce3b7560b1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tiff/libtiff-dev_4.5.1+git230720-5_loong64.deb
     digest: 56033bdf7bd17609fa7eb714726113303a0bd3bb7cbc95547389a7167d871510
@@ -1432,26 +1498,62 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tslib/libts0_1.22-1+rb3_loong64.deb
     digest: b2217959e0d34e5ce86a75b82acb235e1b887696044937815544c576c7abc9a7
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin6_loong64.deb
-    digest: c38b8a0ff42b40be8af246363fb2a07a6cfe163d48201681f9e382612c998100
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-mu0_4.0.1-3deepin1_loong64.deb
+    digest: 9ab1a7f2e07de0e3025492ca143d1e69e1e4c453470e947d0348fd657fa390d3
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-rc0_4.0.1-3deepin1_loong64.deb
+    digest: b89208914d899ba60581d0655be29c62843c3b903fa3c9b48b6f05550117d7f8
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-sys1_4.0.1-3deepin1_loong64.deb
+    digest: 3f4c49b6d25690e4a5f0250a9f90377c85c7fa9c76b42e4434a6091a2abdbe6c
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-cmd0_4.0.1-3deepin1_loong64.deb
+    digest: 8791c36d30de64a15384e68fd6a2fc2c3d167a5288061973cc0d39bc69d2842d
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-device0_4.0.1-3deepin1_loong64.deb
+    digest: 3fadba5f2134b074e499226c9eb06f80e218c74d62c2869c03dc4f69faebf3e2
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-libtpms0_4.0.1-3deepin1_loong64.deb
+    digest: 06c6417aff996ee508edeb82df05df711bf43f3f22824a8fc6615b7ca91e1b7b
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-mssim0_4.0.1-3deepin1_loong64.deb
+    digest: f2d8119b8494daa4ac52f98c5fd35fc404911a5421570261ad1710979184cdf5
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-pcap0_4.0.1-3deepin1_loong64.deb
+    digest: 7557f14d726d78308bb6d08ca9e6f8ef1f2e1a48c30cba1d29195b2ac824e1ca
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-spi-helper0_4.0.1-3deepin1_loong64.deb
+    digest: 932f888b0c1813b41714cd93c445d88082bc26a01764dd6eedbc1ab0de1d63a4
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tcti-swtpm0_4.0.1-3deepin1_loong64.deb
+    digest: 81f59339be44c241bf1f24e96ed153ee7f91508603d9fb61515cc833393af422
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/libtss2-tcti-tabrmd0_3.0.0-1.1deepin1_loong64.deb
+    digest: 2f3e072684d6b5bd645bba188c73a3685f3636d0efdc74f49ca1085439913d4b
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-tss/libtss2-tctildr0_4.0.1-3deepin1_loong64.deb
+    digest: 823244e1fc3b4631ef7a8db48198d6b89761c9131f4b9d71210c9cc08443c610
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/twolame/libtwolame0_0.4.0-2_loong64.deb
+    digest: 62ab9f3a9467e09cb86d27e1201e94435e96858fc0afbfe48a6760ab75902d17
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libudev1_255.2-4deepin11_loong64.deb
+    digest: e60fd5fd032a8f940a703134978d2ff8ad7b702ad7f9d8419c0529a720759671
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libudfread/libudfread0_1.1.2-1_loong64.deb
     digest: 52fe8c374d5b0f18d538139bb314839f707a1ee6da3090d411fb9c2aa9c93e49
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin7_loong64.deb
-    digest: d0532027aebc7da453c7dc6d0613ce21aad5d00c8500a6d365742a59b8ec782c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-0_2.10.1-6deepin10_loong64.deb
+    digest: 5bde07ab9c215ffd5b04ef5042323f7b251b9347058c8e48f4b73ff9a72d686c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin7_loong64.deb
-    digest: d4a6ba31fd8f171c93ce40a51a41fd13b8a489d334edca5641993bdf5a8a23bf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/libudisks2-dev_2.10.1-6deepin10_loong64.deb
+    digest: 39afc45936e6355271254995cd53a7198ee3d8637c183e242342c3a25ba25b4f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2-qt5/libudisks2-qt5-0_5.0.6-1deepin_loong64.deb
-    digest: 4e16415b94708072da530835678134badcc0276e785d0ecbdb68f10062f20c4a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2-qt6/libudisks2-qt6_6.0.0_loong64.deb
+    digest: 33514b960f2e3092c3f22b947182e6e2906ee12204287460726730ada96dac24
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libunistring/libunistring2_0.9.10-6_loong64.deb
     digest: 100d2bd250eff9cdc1ce0492cb7fffc306e620aef5886e1b12245f3f020d569c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/liburi-perl/liburi-perl_5.10-1_all.deb
-    digest: 485904ff807b96c4d1d18d248a40b01915d37274df732235119ecd2af01f872f
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.24-3_loong64.deb
     digest: c95ca8c43cd4b273d9ed19470371acf2167aa90a9d276fd57e9caab50c4df95f
@@ -1462,6 +1564,18 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-linux/libuuid1_2.40.4-3deepin4_loong64.deb
     digest: f3e5aa1a85b3ab2076819261a56469b215cb519efa66d6417065e1826ca7a6ac
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libv/libva/libva-drm2_2.20.0-2_loong64.deb
+    digest: bbbdab85f21232ec1d4f1522042a0870fbdc5561814169b40702b4652b65816b
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libv/libva/libva-x11-2_2.20.0-2_loong64.deb
+    digest: c7f773c72c5f5b6ed54a1734e03513d4e210f34485f22e33186f20f4a57ff6f1
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libv/libva/libva2_2.20.0-2_loong64.deb
+    digest: c9b43b4eba7d7a808c429e72008944b8c19989cf3d7ed95c03a31f72fe9d8c26
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libv/libvdpau/libvdpau1_1.5-2_loong64.deb
+    digest: b1fa2eccc60fa8e56e311145d90a5f293a5422e46387c8c7fb3d352151c47d59
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/v/volume-key/libvolume-key1_0.3.12-3.1-deepin1_loong64.deb
     digest: 49d6752c26177e2e3bb5cbdb1e4bd0072cc82f69ba1a02a357387b08d2478fec
   - kind: file
@@ -1470,6 +1584,12 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libv/libvorbis/libvorbisenc2_1.3.7-1_loong64.deb
     digest: 5cdb7cf3b7e5750527c1eb4a33e3907865783979f1e554b97b0a83cbc3bc7939
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libv/libvorbis/libvorbisfile3_1.3.7-1_loong64.deb
+    digest: ee8791150f1bfe803c6dc3cbbb699a5f6db83f9acea98d0d7af33db8cc50d929
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libv/libvpx/libvpx7_1.11.0-2_loong64.deb
+    digest: 87761187efccb8f8f00932cd8e54936a5fa674fde974afa5cdfef2d91868f989
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/v/vulkan-loader/libvulkan-dev_1.3.268.0-1_loong64.deb
     digest: 26506d91259634d45f99029bf6f969ca5b0e81c39630b0cacb7bd8f959e628f8
@@ -1489,11 +1609,17 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-cursor0_1.23.0-1_loong64.deb
     digest: b457f29596f3639d06b47104e9e9f34bea93014798fcce7aa018a27ad6d6b9ed
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-egl1_1.23.0-1_loong64.deb
+    digest: 4e655f5649746492fde24c2e036909569787beebc4aa349cfae8e849bf5ee3b2
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/w/wayland/libwayland-server0_1.23.0-1_loong64.deb
     digest: 4857b80945e09375cdbf0caa322f75fb243f8d6d97cf31bfae8111854f40e11e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/samba/libwbclient0_4.19.5+dfsg-1deepin1_loong64.deb
     digest: c11be4b9bd319d4946a9ebbb5d921d84b0527fb24d46031a2195238f1bea6a64
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebm/libwebm1_1.0.0.31-1_loong64.deb
+    digest: e94dcc495430d1a7cbe0c2130043ef0db8037519e7d82550d5b62e9fbfe9959c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libw/libwebp/libwebp-dev_1.3.2-0.2_loong64.deb
     digest: d1393a8e0ee0c5e7110a47cd729f042ac19b418bc2560f4fcb330ff1addddada
@@ -1525,11 +1651,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libx11/libx11-xcb1_1.8.7-1_loong64.deb
     digest: 727ef7465319b0edc7070f9b440a76a29ac1437608a23d98e5679f06d94f6fd5
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/x264/libx264-160_0.160.3011.1+dde-deepin_loong64.deb
+    digest: 0c2e8d6f6a31c91f056bbd561ad300f498dfafca6616fe34f4acb5457ef6accd
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/x265/libx265-199_3.5-deepin1_loong64.deb
+    digest: 7e6ff46a8ef0f5ceb00173fa0ab6ffdfa723cd7df39026a74b67b1f00780cad6
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau-dev_1.0.9-1_loong64.deb
     digest: 15f907de0f88e9aac91b9fca3c609de2330cfe0c847b91d73ed5f3e2c4d098f7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxau/libxau6_1.0.9-1_loong64.deb
     digest: 13a646d0cdb63a9a5025ab6f5f692e077b51b5735fb06a1300f6fd544d6496bc
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xavs2/libxavs2-13_1.4.1-1+dde_loong64.deb
+    digest: f71a806a15e1fd259ad7c67c41aca0543affe2673ed1bec8198813c62b3829eb
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xcb-util-cursor/libxcb-cursor0_0.1.1-4_loong64.deb
     digest: faa6e26dcacc1349e55f3d40813207148897ff77d47c34ff17fb6585ede18f79
@@ -1576,12 +1711,6 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xfixes0_1.15-1_loong64.deb
     digest: 604e97953f434b25d0f23f6eed233ed6a797612c2de320262fbb1dff394f9075
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xinerama0_1.15-1_loong64.deb
-    digest: b77443ecd34f97d68467689a5d7247170fa1fc06910c19cfbf8d160a8e901d49
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xinput0_1.15-1_loong64.deb
-    digest: 4fe01e9c81e5b0f199645e25d5ee57837a035f46e50db39193cdb58655bc45da
-  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcb/libxcb-xkb1_1.15-1_loong64.deb
     digest: d00aabdea0d36cb2980759bc6a56de64b6f74810aa8c25a31dc674ffe40c5f2b
   - kind: file
@@ -1599,6 +1728,9 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxext/libxext6_1.3.4-1_loong64.deb
     digest: 151ada3ad16057453b554909ae0ae403c46b8d5560643043a92f4a18ca069de0
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxfixes/libxfixes3_6.0.0-1_loong64.deb
+    digest: 12c47fb6cbb173e015a075830b727791bf872ec2491e789658172f714566d297
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxi/libxi6_1.8.1-1_loong64.deb
     digest: 87c3b78f2e6507074344c7afe0c56aee5a833e8076da0f43ddee28ab53d922f6
@@ -1627,14 +1759,23 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxpm/libxpm4_3.5.17-1_loong64.deb
     digest: 880745da8f29e67626ca68296e048ab6a072ea4c8f1c2ae6f17475285d39eec3
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxrandr/libxrandr2_1.5.2-1_loong64.deb
+    digest: 4804d0fe64eea7ee0b6e687d32c0a80390456c6a7882ef8bd7bb5eab7bef76c6
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxrender/libxrender1_0.9.10-1_loong64.deb
     digest: 8b25a070d6897778e58585524e411ce4591bcc37a642e0a202e064486906e8a3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxshmfence/libxshmfence1_1.3-1_loong64.deb
     digest: 0d235925c3c0d5ff0a3be29607a3800e616b58fcb46b0eafb7a9e3ba70d7d0fb
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/x/xvidcore/libxvidcore4_1.3.7-1_loong64.deb
+    digest: df6e32f02df3fb4156ae67404a2b90539a38f12abe66358e83f80c4c1d80c6ca
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxxf86vm/libxxf86vm1_1.1.4-deepin1_loong64.deb
     digest: 8bf8c69d8210c9e7ca528ec7bb43bb8c39c9493cbe05aca024926e68602b83cd
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/liby/libyuv/libyuv0_0.0.1888.20240710-3_loong64.deb
+    digest: 5db04094a96e73a685b42d380eea7a3f3b84feeb02d941531246ecf45345d6fe
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/z/z3/libz3-4_4.8.12-deepin2+rb1_loong64.deb
     digest: 16dfedbf2e2e2882ca15f980b7c3df0b57a2a0989e5a6bf94b84b4847a68257d
@@ -1645,17 +1786,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzip/libzip4_1.7.3-1_loong64.deb
     digest: 2211ba7bf374deb1ed8bfccff9ec6078735d9b141bf9dccd1150e922a9d97420
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zeromq3/libzmq5_4.3.5-1_loong64.deb
+    digest: ea9300e3470746654e2977f1f42d4577d502625781cdf053bea7aeff012ea17b
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd-dev_1.5.6+dfsg-1_loong64.deb
     digest: 542cb13caf60619314815e4a117fb1e39c3540a241aa52a34fb9cc7b4717f08e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libz/libzstd/libzstd1_1.5.6+dfsg-1_loong64.deb
     digest: a4bae41cbfe530058e9c63f4b3c34294f1b4b726d8f022b9eca8f7e81833fe13
   - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi-common_0.2.43-2deepin1_all.deb
+    digest: 8c4f70100c1fcb2755b08644f2326f0c42cf037e89c22cb69e4d0dd0798cae8f
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/z/zvbi/libzvbi0_0.2.43-2deepin1_loong64.deb
+    digest: 3a04740acd8957ba0e5eb2a4266d92ddf4bdc9c12b2c2a75ae868ef24f1cd189
+  - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/linguist-qt6_6.8.0-0deepin3_loong64.deb
     digest: e200be025cd227c34cb852eb20d4b7ad0d371095fdba7b7c4febc7ea7a2221e2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_23.01.01.24_loong64.deb
-    digest: 48957a988f750077b429a1e8b7f54ab5a6563931d4292f750220078741ed8ed9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/l/linux-upstream/linux-libc-dev_25.01.01.01_loong64.deb
+    digest: a594841362d365a0b93ae0462935964f0efbb0c90da4be064351388804154202
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/shadow/login.defs_4.16.0-7deepin1_all.deb
     digest: abed558f44fdd893df5020fdd787b2ee1b5cbc8b5e4b78ab4b01b8f1cc1aad08
@@ -1675,8 +1825,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/media-types/media-types_4.0.0_all.deb
     digest: cd124053950ab8b0373203bceb7eab841791017daf1d50db2ece09e4da52406a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin1_loong64.deb
-    digest: 4011a3103fc4a1f79b11f08403b2e636eaa7f593fc5ceba3c2e00c2e774a5a18
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mesa/mesa-libgallium_24.3.0-1deepin4_loong64.deb
+    digest: df2142c0fe0e2665b0f4f7068f4c2aa5d4f5fcd564b2fa570b993c83598dd157
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/m/mime-support/mime-support_3.66_all.deb
     digest: 20294deda4378616c2b48614ee226731ec09663c3497c35a467e8ea5fa03f16a
@@ -1686,6 +1836,12 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/netbase/netbase_6.4_all.deb
     digest: 5fd05a5d63864b96453ba55a4c5efa287b8e7e53fbd833e7a944e066d30e1eb1
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nilfs-tools/nilfs-tools_2.2.8-1_loong64.deb
+    digest: 07f898fd00dcdbd55dd88e48dac540ae60c92548a2ae6949e930974cc7bf2897
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_loong64.deb
+    digest: 8569bcf5afca194968c0e49c3a71fbf106bdb5f6281db535142a5b8ea1a46e18
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/parted/parted_3.4-deepin_loong64.deb
     digest: 32e8c2d16d323e6f03b2b6ab0f011663593d583fe91f1d46a8f3f50640a72a8b
@@ -1726,11 +1882,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python-packaging/python3-packaging_24.0-1_all.deb
     digest: acf9e0347764b07624b219b64fa7721705d6eeea5a98871f892aff3ab0293ae4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.4-0deepin1_loong64.deb
-    digest: f90145024163b5f423db6765b8ced01439e819859419cfe9eb9fe7ffc6cfd0f7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12-minimal_3.12.11-0deepin1_loong64.deb
+    digest: b4144ee10587be066eb49793ff81bdf1e6542b4398a99bce1f61660fee4bedfe
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.4-0deepin1_loong64.deb
-    digest: a003a420b5bda72fb4bbea54eaf3a3a3c74fea3c741ce8141646832b82140be0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3.12/python3.12_3.12.11-0deepin1_loong64.deb
+    digest: ea8a8be4b657b9b94b2a1e1fb27fff9a7fabd64a17007147088feaba6a7a970a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/python3-defaults/python3_3.12.1-1deepin1_loong64.deb
     digest: 2068886f43d893b3d801afe06bdbed2ac6cfbd3dd14b1d2b5658fb691d45615e
@@ -1738,11 +1894,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qdbus-qt6_6.8.0-0deepin3_loong64.deb
     digest: 99aa344e806f799b1008841a76c4f83ad58f508aa7216f7df5adae3aa860fdbd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: b2c23ea458f84eaf5df7f06ceeccf24047551cabc4abd35782060399cd2c8ad6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6-bin_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 339c762f9680d23b12e5ac41068c139b969cf6d035fd286bac37cb3dba4433f9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 4a50a0bec4830e8b4d5468af3ca9b8bb08bcea4892539c2133c6cfe8d06889de
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qmake6_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 8e412a2aa98348c58e7f528fd04c00feb90320acc2b6cbed873c3094890a49ec
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtqml-workerscript_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 352c93151474b4e0843755cf4248d5678df53a42e9058d07408427a848b52b08
@@ -1759,14 +1915,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-declarative/qml6-module-qtquick-window_6.8.0+dfsg-0deepin3_loong64.deb
     digest: 2590de7981ccf897e21ec9320716013275d4a27586af967ea26fca501ac2b477
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qtimageformats-opensource-src/qt5-image-formats-plugins_5.15.8-1+dde_loong64.deb
-    digest: acad29301a55d860cb5f300422fbf0600f20d39dea780e9bce507f0a05c18f18
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 8bb4163c0c9da5c501f1937e79f1f9db15bc57b502de5d711f51239748d3c1ce
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev-tools_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 2e76edf66678b456d8d2772efd47d38a50c140d74084a166fd2faf1a63da2b00
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 6cc78a068f206bc90e8cea49b01dac72ac0356213fe52643cec12a23f6b82353
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-base-dev_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 61fa7ec1e9023d7c55286b469b6238769eb86b1fa2cfdd45aaa291fe2005e57a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-documentation-tools_6.8.0-0deepin3_loong64.deb
     digest: cf6fafc95fdce9f99b2bfd283100163a1c316fc596dd6ab9da30821d1faeb0d5
@@ -1777,8 +1930,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/qt6-l10n-tools_6.8.0-0deepin3_loong64.deb
     digest: 64b8adf192160cd12b0e63cba2d112fe0f0f361f83df2666c5017e55e5383fd9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin5_loong64.deb
-    digest: 13e2e5d5ae5fbaa5b971f6e5d4b48c1d72cef2e77af4344e7b802e0f4170228b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-base/qt6-qpa-plugins_6.8.0+dfsg-0deepin8_loong64.deb
+    digest: 82c70661bd53c58e196bbfede69b23bd2bcbd36829aeafa838cdaa4627893a98
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-svg/qt6-svg-dev_6.8.0-0deepin1_loong64.deb
     digest: 8d025380c93576e65ed0941ed9b0a568d366c9554497570335f4426be7068545
@@ -1810,17 +1963,26 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/socat/socat_1.8.0.0-4_loong64.deb
     digest: d47dfee9994b6a605fc853618ad52f2bce3b45484a916123b7e83d10b0a2b85a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-dev_255.2-4deepin6_all.deb
-    digest: 41bec4491af5737e55f1c186ec8bd05d24611dfaeda7132354e75ccb6ea7dd68
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-dev_255.2-4deepin11_all.deb
+    digest: e6e0aef2dbe6f5df8626b630c52d8d63830e2979730b54839e7f84fbdbe34597
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-sysv_255.2-4deepin6_loong64.deb
-    digest: 204a94e1ace3a3835833361a0deda9e1711211fed52854943f9c5d4e600f7760
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-standalone-sysusers_255.2-4deepin11_loong64.deb
+    digest: 77203f5eaa980c663c645b76c604cc7389b6bac9e04dbc5c6ac42b8031422144
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd_255.2-4deepin6_loong64.deb
-    digest: 750d3a99b0f00a52096d22df01310c608e255cf1449e3bff5f453bb515af29a2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd-sysv_255.2-4deepin11_loong64.deb
+    digest: 4cbc37c83660c18cfc127e4694a4a83d77404dde63f91d3f1ebd2789608f7ea3
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/systemd_255.2-4deepin11_loong64.deb
+    digest: c1570358957ab65e6b86c723b409cf3047c9c0e9522591155f92c102f87f2eea
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tar/tar_1.35+dfsg-3_loong64.deb
     digest: 48cc0cc32829c68c7b58e74f141fe552f9a3f5c9e6da77ad54184530debc0cff
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm-udev/tpm-udev_0.5_all.deb
+    digest: 8305c01b236dc4838bfd5f3331c403ed344207b35808d4bbb76dd58471a65b60
+  - kind: file
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tpm2-abrmd/tpm2-abrmd_3.0.0-1.1deepin1_loong64.deb
+    digest: 6b0804db4517efcfab00314e0570156b58cce81d9cf4df0308f2cedf4762cfc8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/tzdata/tzdata_2023d-1deepin1_all.deb
     digest: fe503c524801260208482a1dfc061e79c2a7450111dd90f88ed40d70ac935832
@@ -1828,11 +1990,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/ucf/ucf_3.0043_all.deb
     digest: 798643dc75a19ab6e0067fcd63a89c28f711c3e4769435e262dc36bba18f9a2a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/udev_255.2-4deepin6_loong64.deb
-    digest: 1b1be113e57f54eaacd13952a63f9cfbabd5c974e58e53cbb15434aa1905cedb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/udev_255.2-4deepin11_loong64.deb
+    digest: 0d817782913de0e170bd8fc045fdadca4953911b937511b0f417acbe79b5d1d0
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin7_loong64.deb
-    digest: be0645c72c2941270365fe915395f1d5013088e0fe317329152602b047171244
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/udisks2/udisks2_2.10.1-6deepin10_loong64.deb
+    digest: 61d95dfeb00ffa5c3082a21a29f600695f2a42edc7cbfeeddf6c4b60046f90f7
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/u/usrmerge/usr-is-merged_39+nmu2deepin1_all.deb
     digest: e8896ae20e16a3b4ab0ab4caaadf884de1c0056ff449f85ff1426415e8758a3c


### PR DESCRIPTION
Update version to 6.5.21.
Update deb sources for linglong yaml.

Log: Update version to 6.5.21