### PR TITLE
chore: Update version to 6.5.22

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     font manager for deepin os.
@@ -21,7 +21,7 @@ command:
 build: |
   cat /var/lib/dpkg/status|grep "^Package: " > ${PREFIX}/packages.list
   bash ./install_dep linglong/sources "${PREFIX}"
-  sed -i "s|/usr|$(echo ${PREFIX})|g" ${PREFIX}/lib/${TRIPLET}/cmake/dfm-base/dfm-baseConfig.cmake
+  sed -i "s|/usr|$(echo ${PREFIX})|g" ${PREFIX}/lib/${TRIPLET}/cmake/dfm6-base/dfm6-baseConfig.cmake
 
   # add path for searching OpenGL
   export PATH=$PATH:/runtime/include:/runtime/lib/${TRIPLET}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.22) unstable; urgency=medium
+
+  * chore: Update linglong yaml
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 02 Jul 2025 16:54:09 +0800
+
 deepin-font-manager (6.5.21) unstable; urgency=medium
 
   * chore: Update deb sources for linglong yaml

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     font manager for deepin os.
@@ -21,7 +21,7 @@ command:
 build: |
   cat /var/lib/dpkg/status|grep "^Package: " > ${PREFIX}/packages.list
   bash ./install_dep linglong/sources "${PREFIX}"
-  sed -i "s|/usr|$(echo ${PREFIX})|g" ${PREFIX}/lib/${TRIPLET}/cmake/dfm-base/dfm-baseConfig.cmake
+  sed -i "s|/usr|$(echo ${PREFIX})|g" ${PREFIX}/lib/${TRIPLET}/cmake/dfm6-base/dfm6-baseConfig.cmake
 
   # add path for searching OpenGL
   export PATH=$PATH:/runtime/include:/runtime/lib/${TRIPLET}

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.21.1
+  version: 6.5.22.1
   kind: app
   description: |
     font manager for deepin os.
@@ -21,7 +21,7 @@ command:
 build: |
   cat /var/lib/dpkg/status|grep "^Package: " > ${PREFIX}/packages.list
   bash ./install_dep linglong/sources "${PREFIX}"
-  sed -i "s|/usr|$(echo ${PREFIX})|g" ${PREFIX}/lib/${TRIPLET}/cmake/dfm-base/dfm-baseConfig.cmake
+  sed -i "s|/usr|$(echo ${PREFIX})|g" ${PREFIX}/lib/${TRIPLET}/cmake/dfm6-base/dfm6-baseConfig.cmake
 
   # add path for searching OpenGL
   export PATH=$PATH:/runtime/include:/runtime/lib/${TRIPLET}


### PR DESCRIPTION
Update version to 6.5.22.
Update linglong yaml.

Log: Update version to 6.5.22

## Summary by Sourcery

Update deepin-font-manager package metadata to version 6.5.22.1 and adjust build script cmake references accordingly

Chores:
- Bump org.deepin.fontmanager version to 6.5.22.1 in arm64, loong64, and default YAML manifests
- Update build scripts to reference dfm6-baseConfig.cmake instead of dfm-baseConfig.cmake