### PR TITLE
chore: Update package URLs and digests in linglong.yaml files

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -88,11 +88,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1+rb1_arm64.deb
     digest: f50240be45b9eeee8f6d27feb462e5fac2f6aaf88fdd9b50f66606ac044a2409
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2.1_arm64.deb
-    digest: 21e8a1333c52d71cf70f28881d01d4a6087ba19872d8d44245fd453af19fbf09
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2.3_arm64.deb
+    digest: 3d138b834e674d2566ea314ae8a45e8b632201b266adfa3f15a71cc91c451055
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2.1_arm64.deb
-    digest: cbc4bf1ab75f244e3497e27fbd9a3b3549c5a8cb9423f186aa8dde6875c8d66f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2.3_arm64.deb
+    digest: 809d1b8a1362b69aed195cd8f849aa8102071f43826e992b8f8178fe4e0ab063
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dbus/dbus-bin_1.14.10-3_arm64.deb
     digest: 1897c8dfbbbfba645cccc34762612e60903f62caa3aeaecaf4fead01105f2c15
@@ -124,14 +124,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_1.5.5_arm64.deb
     digest: 73996d69cbee52621dd9203a6117d0c54f74bdb8a52adf67da7ae074fe56647d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.69_arm64.deb
-    digest: 49dc51c8e480b4be5e81bc005da73d535d8cc5af9ee074d90282d0446423d843
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.74_arm64.deb
+    digest: 22a1938b2a1fff09abc42c854e5bab3c5baf1ab45495ee94f7dd863b611ac7dc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.69_arm64.deb
-    digest: b0513e9514efd12990910f07fb69532cafe9a9af259702b8cc7c1771b01c519b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.74_arm64.deb
+    digest: 765ffee9d22166a9aa2ea0ee6727266f9b6f77153f3aa03bf0ab512728f51637
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.69_arm64.deb
-    digest: b492bb71f0838cfaab2bdf97fcdb3018b9141220603fe5d5a687f7ba0080c564
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.74_arm64.deb
+    digest: f23bc94c0ebe9cbb03318e588008e866cc40c19ebe612407f14fc9080d928739
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
@@ -142,8 +142,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_arm64.deb
     digest: 11a42f07b2feefb7669441c3a67176cc32dc857c7d21b3290c464795fc514448
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/desktop-file-utils/desktop-file-utils_0.26-deepin_arm64.deb
-    digest: 6e1b40ec986b3d9615bc63779c4898978dcd2d9b770c866e86cbaf2ab2b5037c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/desktop-file-utils/desktop-file-utils_0.28-1_arm64.deb
+    digest: cff180f2880aa28de5120032fc2e2a52c0a210f02d113e15280476a4c2f9c4f3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/dirmngr_2.4.5-2_arm64.deb
     digest: df5cb4feb19c5037ddac50f250af69e4106dd9de5f8a71e517f8f3644e296943
@@ -157,11 +157,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_arm64.deb
     digest: 395526d8605c5a34c3bea89d6c32781d3a5625eae82b77f598835c09524f51cb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_arm64.deb
-    digest: aa64934dbf43b0dd0ffee2b7fbcce324b50b957b0a4f04c10d062a85d8847d8e
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_arm64.deb
+    digest: bedadcad1a6b77ae2842cb308003cfae181d382ee416ccbd9c35e309f1991d19
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.14.2-6_arm64.deb
-    digest: 91c105d210849f97151c436e0cf9b77910bbc58ea9bbd40da4077219def10994
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_arm64.deb
+    digest: 6d7e0dca9ca1599c9950826e6c25918a3b30e7a37222ef980ae64fff2db42535
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
@@ -322,20 +322,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libavc1394/libavc1394-0_0.5.4-5_arm64.deb
     digest: f4c42a206e22196ffae860df9721e1b1dd22a1a90e6879ec47e0f02e4215ce70
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin2_arm64.deb
-    digest: 8d24a40a05ab5ff7dee8d5180acb049c984a18dafd632ffa23bf1c02dc4c1d0c
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin5_arm64.deb
+    digest: d3925e1b4b6293bccb43b9ba984854fc1efd476d7876dc0ea9641b5063694d8d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin2_arm64.deb
-    digest: 6187c73e1cac5a58003fdff97e19429f79d3a4ae527e37b66022614289d7bcb1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin5_arm64.deb
+    digest: ffa544c8190db95bf29d1c0ed7fcfda63fe1646b35cfdb48fd8c9dc7c294ef0c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin2_arm64.deb
-    digest: c1aed93e7d684d49f52f650f8af8a954f1137b24fd037573cff9302c05e65779
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin5_arm64.deb
+    digest: 44c9517263c348c927e8e03abb3889209b91c8acf76850dd6491b4a073a6065c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin2_arm64.deb
-    digest: b309056f6e2f2b4d21606204ef7d585b3c087d8dfe7d88d79f46312a9f555f2a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin5_arm64.deb
+    digest: 59e2e608181be0f63c16d36e35f6cae96e5d18754b78f0777f2b6e66380cf89b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin2_arm64.deb
-    digest: 5d0554f80e21505d1c8f016ec911de7adbf3692150995243d806c68af667591d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin5_arm64.deb
+    digest: add697813f2bba7bb8fc228999ba8e42b66ac641fef1269f492144ed496a99e6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_arm64.deb
     digest: cac541f3cf746d006b71a08f88364b6743222b8956fda9a7cbd35ffb1cf32ed9
@@ -499,8 +499,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_arm64.deb
     digest: 037584e67001e5de6f78c0d3acabe70a7b2e7dc592252ae0d9397c263c41c9f4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2.1_arm64.deb
-    digest: f0f203eb6009c93788a6add455c76c3ed52211069d6b559d221842ff6a1919ae
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2.3_arm64.deb
+    digest: 1ec0d911dbc29f2e488ac4694f00d318112969a67b0a0baf047a720decc12439
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_arm64.deb
     digest: e34f53bdde8f49dddfcbd7daa63d613f5c71b92d0e79683b500c8bccd0866bb4
@@ -547,8 +547,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/libdconf1_0.40.0-2_arm64.deb
     digest: 57f0d64bf483877f4c8e4bec0eaec73227d30795dba37aa6ce726b6816c0abef
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.69_arm64.deb
-    digest: 13b8ca924353f9e25ae78aa287a8bb141cd59341cdb49c779d58a7b403109889
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.74_arm64.deb
+    digest: ad0ffd25f03f97495c755bf1c8eb99e215a8bdf6e700422a5330d1d9ed099c1d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libde265/libde265-0_1.0.15-1_arm64.deb
     digest: a13a2d2c3ba13b8f1d8bfd8b657665d3b1666c6fc954c16c8cec972e5af01c47
@@ -571,32 +571,32 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_arm64.deb
     digest: c323c31508b8e23cc1b44a3a45920288f17d6cb3a6ae7d53746a3bb2a9a982a1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.69_arm64.deb
-    digest: c8f7cf58fa73811d1b176bd7facc39226cddb991be5c341fd9f91a5ad1f7aa9b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.74_arm64.deb
+    digest: 99f0ba762b55a3f66093da749647df3b31c27aafadeabd13f4f493d6b40925d1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn-dev_1.3.31_arm64.deb
-    digest: b5aec30e7802689f86610df227a51bf3e64675a872f2542fdab1aaa6bba29c72
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn-dev_1.3.32_arm64.deb
+    digest: 80505997622985fdeedb0eaae5daa68c611a2b3d47f6563101005fc6ae32ac38
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.31_arm64.deb
-    digest: 3876ac5ee7b3a08ac066a4427d26a4bed2dcb8d3bff7750f96b6b27e585f4e0b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.32_arm64.deb
+    digest: 3c77dfb4ed59eec1527e5f010b141eb2b59533af67fd5f99e9b2e089aee75de4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io-dev_1.3.31_arm64.deb
-    digest: aec561bcb897500213f358ce2454709f57f30f5f86824e9e45f3befa6dc668d0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io-dev_1.3.32_arm64.deb
+    digest: ff26d0b4f5af2cf29cf1563ebc48ea9e53a19e6a0b922dc3ada14feea5ee95ff
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.31_arm64.deb
-    digest: dd56c60397ae436a8e5fe3caada495b9a2a78902600ec9dc47e8774d697cc0f2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.32_arm64.deb
+    digest: 5983a2039e0accf6cd887bc0ebb891aa20b9de6867b79e41f88feb51d853e838
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.31_arm64.deb
-    digest: 18670128ea0140e7e8e3bf95fc83261daf6ac2874b9f42522b20a3973e65ba74
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.32_arm64.deb
+    digest: cf26e08fe67b9866846e171dc1a1a73cf7b2bfcf6de6d7d71eded0c2e6bb5273
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.31_arm64.deb
-    digest: a6f5356b4feb451d52d63bf7d6215fda1fd49022903a3485d2b7da709b3987c3
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.32_arm64.deb
+    digest: a30a89229adb01f626642f3637d8f89e3fc572c87750a5a4744c5311f592b9db
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-search_1.3.31_arm64.deb
-    digest: 9a1a5dc487ccae38d6c4c6eb832f5d0316348f2d72f0935cd0369574c55ed072
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-search_1.3.32_arm64.deb
+    digest: 34f77febd7efb47b4b13fe98365c4422ee280cef2b2ec93f2227809c2285ff94
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.5.17_arm64.deb
-    digest: 25408acfa53a0295062e2a284aa0396556d701e76cc8060eb8351484be1083ad
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.5.19_arm64.deb
+    digest: 48e207bc245fa0c34ca1c6135c24d48050a14ccc81b535e6fbc4a33a5f77bca3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.21_arm64.deb
     digest: b680701b4a5f9d42e4eb1bc6e833efa54332a1c78ea2b76a9f36557231445680
@@ -712,14 +712,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_arm64.deb
     digest: 65fdd731df6fc44891d7c77da9d16717fd23df0d4251085dc0c43b4313e903eb
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_arm64.deb
-    digest: d965d2bee11b03bb0b86e876a78f5f3b3f5ae3b66ed3f74a8baed4f1a2edb058
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_arm64.deb
+    digest: bbbc845e4a6ade7d6fe9d7147e9891f1bcb60c971ef8d0ab7c253d7089fc1f8b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.14.2-6_arm64.deb
-    digest: 6a01f4bc5a0369c10ce0021b23b3a4985c54672a05714b17b736f364f37805fb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.15.0-2.3deepin1_arm64.deb
+    digest: 9c78753391c48f96ee3f099ad88d28c262f96c1b0f295c7d04e4c941d0e588e9
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.14.2-6_arm64.deb
-    digest: 2088236fc9be4b0b363707d88c00eac4c082aa64f00c10f869c33884dee5772b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_arm64.deb
+    digest: 82b4c63adda13ee062e7cac011f49859d31b911c5e64678d8d1404e5da3a92da
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_arm64.deb
     digest: 222148f71812a1026457b2d86edfe68eac087f0063ab5e8159439e3d11793425
@@ -916,8 +916,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_arm64.deb
     digest: a1910186258a924c4367673da786e7200f32e54ea54f65e2b885e3e451197e0e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin1_arm64.deb
-    digest: 42945fdc780c0d2259efde9403abec12c1c65f17f131a49c4a282b720e8cb2ee
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin4_arm64.deb
+    digest: d5bc8f5eb78bf50444fec39a361f43c52b13d13a9c2ea45c272b05d1c8afbb5c
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libidn2/libidn2-0_2.3.2-2_arm64.deb
     digest: 66be80634fd2243b4741bc12bf02ae140d4af694da58e23415130322eb8e17cc
@@ -1282,8 +1282,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/popt/libpopt0_1.18-3_arm64.deb
     digest: 17a7cf13b9c83ff20f5e8f099198ccb74e100c07e1e817fa7c4e1faec2dad159
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin2_arm64.deb
-    digest: 55e73753b0ae18a65a7aa9c126f52524a93888f7cd2b8fe1503a9cbc140cfb51
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin5_arm64.deb
+    digest: dead175491c1ee86faacf68a361f8acc700ff340d008c99ce51cf7737c1ae438
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_arm64.deb
     digest: c4961acabed64ea88a254ba89930110925ea89fb182f5d088e428503d9c531fe
@@ -1546,8 +1546,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_arm64.deb
     digest: 359f8bef6d4a77cd5875d210c50dad400ba3cb6625929fc9fbfa5d56d6027a02
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_arm64.deb
-    digest: 830239bef63460fabeb07413177ff1377da7b67edb62fb4710ee06c764f232c0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-4_0.11.2-1_arm64.deb
+    digest: f6ff61ff1705a16acee52e75507683c4e78666689e2e49320b3eac20d099aad6
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_arm64.deb
     digest: 08093eb78fa9240413e29c306f3af7f2ce9cd2599d0905cbbc48166518849895
@@ -1564,11 +1564,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_arm64.deb
     digest: cc104e0d2a339b388906430c5ddde52273cf42871c3d5a1c488732d17647e782
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin2_arm64.deb
-    digest: 74bdd2a07078ea6a0934bfc4bbdd5a6a722f5c808f0b397bc87430ce4b822da1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin5_arm64.deb
+    digest: b47fc42e5ffad34c8757033f03003ccc5015de52efc8c6662b0cc4d97ce30297
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin2_arm64.deb
-    digest: 60b250c05f6bbc0a570f2b484a50b2599b90e73a3616acc0fdaf9cd0d4958d40
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin5_arm64.deb
+    digest: eb6fb17c3de6c25e75455e9cc789070d7e233c77755c5ff4e9aa901e0f1fee8e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_arm64.deb
     digest: 41ff44785effab7f081c3d4744d9e9cf25e374c13a00ab8ef93052a0a4d57114
@@ -1579,11 +1579,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_arm64.deb
     digest: 694573210aea6173c54cc5084a8c29aa2001200e0a1e2144d6338463050f3979
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_arm64.deb
-    digest: 287d31cf9321b19b5c7d104e8e1be43c0e6c4536cd64eab2b6c9813ebe1772b5
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5_1.12-1deepin0_arm64.deb
-    digest: b39662c030536a2562c91ab82dbfb6c876062b277fb0a0bed667030e8b288872
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag2_2.0.2-2_arm64.deb
+    digest: 1594f7a4e760da7851069bc151a6021d42194f553bb6eea9da8c643fd194c0d3
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/talloc/libtalloc2_2.4.2-1deepin1_arm64.deb
     digest: 2bd050de54dd440cf6326b821a4b2902b4b9a8b3f351dea22468a514c64917ad
@@ -2002,8 +1999,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nilfs-tools/nilfs-tools_2.2.8-1_arm64.deb
     digest: a85b6cb8ba4eef83d9b033f905284a15d1ca3e4a5ef43174ac2c251c1b50e84e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_arm64.deb
-    digest: 2411c1cc39eb107516938b83b1eb50c29e9a6deb232723d65e17cbf592df8609
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.3.3-1_arm64.deb
+    digest: 0bc26fc52fe1ee1f328e814871a257169d1844be51b74531ce255104ef6862be
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/parted/parted_3.4-deepin_arm64.deb
     digest: fec80e4fa8a94468473d93960d4229dbd79f027298757513b2575b96409bff73
@@ -2025,9 +2022,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pinentry/pinentry-curses_1.2.0-2_arm64.deb
     digest: 6f1bd2f453605e6f2847629cad4a87609debe25f9ac1ba2652a343543caf1b94
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkg-config_1.8.1-4_arm64.deb
-    digest: 8b40ce5f7439c482fa8800f2a60160fb34fd46492d8ed397480ca0471b7fc9d8
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_arm64.deb
     digest: fb3f32b7b567509b63afab51fdf5afbef9f9af569f10aac490b98d34feab8670

--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.23.1
+  version: 6.5.24.1
   kind: app
   description: |
     font manager for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.24) unstable; urgency=medium
+
+  * chore: Update package URLs and digests in linglong.yaml files
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 10 Jul 2025 17:55:33 +0800
+
 deepin-font-manager (6.5.23) unstable; urgency=medium
 
   * chore: Update linglong yaml

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -85,11 +85,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1+rb1_amd64.deb
     digest: bb725bb6b5628391b35c88496a1f793a1b19220024631d0c2e7444206020ce44
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2.1_amd64.deb
-    digest: a3d66fbf7e609dc595c342063c2296e65fc6ca7b0832875827e91694f5c2d44b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2.3_amd64.deb
+    digest: 27fb1076c293c584a31315ad833251bbbd7dd94da316b99f83d52fef9a27c79e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2.1_amd64.deb
-    digest: 9b73d9cfc9c3de4cf6c62607b916d93bf14052c80056554aa37b85c5fd3f6280
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2.3_amd64.deb
+    digest: 546af3f11fd66bd2a6ce7f7fe23b7c083647b06b69418932412a121002340dd1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dbus/dbus-bin_1.14.10-3_amd64.deb
     digest: 703c756370944c7e301d5c855350dd66b8df46bdae735399138afb9dc3fffa55
@@ -121,14 +121,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_1.5.5_amd64.deb
     digest: 6fdb4a1523b47ee8db62c93786f7f1f58e24de681b9164765d045dc01f60a736
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.69_amd64.deb
-    digest: db64ea48a6024a5e2861b85bbcf1a1a8f25127377b5b15d01c639c3c2881613b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.74_amd64.deb
+    digest: 0cab582106c0dc304894e9ed0b17e6fab6a81606073d7bb7356ca0639bc8c20e
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.69_amd64.deb
-    digest: 5fc4737b548d24885569bc9bfb486dd1e1a16874bf156357ce8b1b448ef18e65
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.74_amd64.deb
+    digest: a5b877b954fcf0a4c2200e47b9aa4b06ab737febf3d2a18585d8576e26a86a2d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.69_amd64.deb
-    digest: 07a12c3847fbd7b6a0728c2aec1bc972eca54b415416970f6be0508a492f4c9a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.74_amd64.deb
+    digest: 8b7731efbaf03a7405efb392365866faa3d2567951da4a76ae4b82dfadcd86f2
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
@@ -139,8 +139,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_amd64.deb
     digest: f0e1fe7a35fc386fb5944eb9bc4325c4e2d8913f43639ab6791ed3ea6084f584
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/desktop-file-utils/desktop-file-utils_0.26-deepin_amd64.deb
-    digest: 9c27ad7ca2d1fcba24a10119a2beae8010d96c4666d632a0787aaa22410f50ed
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/desktop-file-utils/desktop-file-utils_0.28-1_amd64.deb
+    digest: 5931c9ad27759f3a6ea5d3ce13b63de88d9eaa1111cfca672adfbe544f88bf33
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/dirmngr_2.4.5-2_amd64.deb
     digest: 56416fa6d0103f9c985fa0a81561d36ef1f4b33a801aaef21a96c07f3a213f26
@@ -157,11 +157,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_amd64.deb
     digest: 2837fb44598aa57a0fc7d2b477c6539b3c268a1312f2580d4fb227e83d023d9b
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_amd64.deb
-    digest: ca239a17d79f439fc02525b3b3c83d6cdf0be1a90c6aa6ec6c19b2b92b0d6586
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_amd64.deb
+    digest: 70df7073f2ddecf0ecce688b92939d7bf31268d37d299a416243dd6a114a96ab
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.14.2-6_amd64.deb
-    digest: 1018476410ec372cb5f96e3a4d4b4d51781c613212eb71f91bcc939c2de0e8f2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_amd64.deb
+    digest: c3c6ce170d17d875a72e644f67be87e47ae19feb7682517eab59259591348441
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
@@ -322,20 +322,20 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/liba/libavc1394/libavc1394-0_0.5.4-5_amd64.deb
     digest: 27a869ad9b0f6673fe4c6e6dc6aae04f58b550fa9f2de4c9c9ba64cda6e9937a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin2_amd64.deb
-    digest: 11c11308dd570baf7d1faf87862c8edd5033a648dac4df9b3a14333d339b55e1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin5_amd64.deb
+    digest: 21cfafe3e4985e50b51425b45a00b896b00d57022fdc139e4ba2e74b14e7a274
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin2_amd64.deb
-    digest: 31e17d96ea0d6f9977833e84d40183a63edc56c408874d4b65b120871bbc04d0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavdevice60_6.1.1-2deepin5_amd64.deb
+    digest: d592c5f97dec2b6666d9a4e306b6838cdfc7033320f929227a6d11c1c2549b8a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin2_amd64.deb
-    digest: 274d9c2fc032c05e8681123e433df396aeac198b820bb4de7ddf415f0eb6a6d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavfilter9_6.1.1-2deepin5_amd64.deb
+    digest: 57d391b0feb1413978910cf3eb8a001a6cca2c765c9cb9df07e4c20d28809355
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin2_amd64.deb
-    digest: 5a9d472dc24c2fca1fdb108e4c63c28f1bcd4cf4921e8bdeaab9920b0c4c6cce
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin5_amd64.deb
+    digest: 8a8253d05168ed6193594a300ff056afdc8b6a0be9603aaa27ea6517335cbd87
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin2_amd64.deb
-    digest: 3af976a0628eafd167b8652cebc99774f561255d338f9e874c9fdf20087e84b6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin5_amd64.deb
+    digest: 12ca2c24eb8bd3be76bc17c151625c897ee0e9d446673985bf945c850a99e9d1
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_amd64.deb
     digest: ad82b2de93cc49cdf37c861b03275245318b1555255639e5e805cf612a40171e
@@ -499,8 +499,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_amd64.deb
     digest: a7af8c9a2b767781d83f60fa32553f6a713569a0f7c4666e68dab41c46feaf1c
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2.1_amd64.deb
-    digest: 612def1dc46e0952a0bcffb16202e5d5f8d20daf5b5d0ba736aa0ce7baa35a72
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2.3_amd64.deb
+    digest: ae51d6f798bdd49881e15d50f2722998f4b3ddafb5498f875565771f1f8cf65a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_amd64.deb
     digest: 44b5e0a887f8b8d84166ba81f4cf1d70b607914c8b59959c47bde1ce750645bb
@@ -547,8 +547,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/libdconf1_0.40.0-2_amd64.deb
     digest: 80248ca6b6f089cbf601cf9f5fe5f65f875a291c8413e1c93067dea6ae746f79
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.69_amd64.deb
-    digest: 285e3f4cb3b12d726d363283a7f0d6e9300821a7f82ec1b4a070aa769be061a1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.74_amd64.deb
+    digest: 53a5a0326867ae48ffc16d165430700bcd45449a37e6d7ba6945099ec5edca18
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libde265/libde265-0_1.0.15-1_amd64.deb
     digest: 70349a1252f96e510b63a9f6ae3ddcf0ef771c82f7c0bd0a6931cb83ad4c5305
@@ -571,32 +571,32 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_amd64.deb
     digest: cd72874d32e4388f985efeec06703b272bc1e09462172dfa52959a18520339cc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.69_amd64.deb
-    digest: 79799f4d58ddd6bd53bad3eb828d9b0060c9c30d6b7075d37d119fcc6c1701ec
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.74_amd64.deb
+    digest: b5e4cf7c4dce6e34df662cf34c44ad42ce37326cafb9b62b97145f8703b0616f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn-dev_1.3.31_amd64.deb
-    digest: 0c9c15c5fecae6ce3de13da7a535dce85fb8a4b4c3e2af6c363dce6f41c7cba1
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn-dev_1.3.32_amd64.deb
+    digest: 3bf0bb687ddd700505542d47113da7ccf5ba7d102781febf6718ae7c09d07951
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.31_amd64.deb
-    digest: fcf8a33774a6ce1aaa432a8b244993ab9119605cf5d5cd63caf25ec91db1ffe7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.32_amd64.deb
+    digest: 8a8e501d9fe3705532c659c7655756356f8eabd76d0118dca5ad756ab8450839
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io-dev_1.3.31_amd64.deb
-    digest: ec8dddcd968e7816fe5c0360ecf773b07f1aa1e9b871b5882e196c947f3c58eb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io-dev_1.3.32_amd64.deb
+    digest: e6c07ac30b277fa1ba7df87ce2ba1e716b2f2ec48b0dc5d7dbebba873cba7d85
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.31_amd64.deb
-    digest: 29640038e219938479219bcd8ee66bcbbe80eb3a49b8033893a3d6b09fedacf7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.32_amd64.deb
+    digest: 2411ea278192e185bc49fa3d9b943c4daa4bac795ddbef6f8175baf8fb2ac271
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.31_amd64.deb
-    digest: 4b52b48a1cae2d698639b03a17ebbfebb9fed9b6774ec35b10eaa7b594b5fa8a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.32_amd64.deb
+    digest: 18a55a3be60b821e0bc224a61b86d0fb93b353804468a48c0b57f904dcfa9373
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.31_amd64.deb
-    digest: e7f3a0684f07c34eea8c4e7537af08fa0b775070084120378d0a1b7b53b62df5
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.32_amd64.deb
+    digest: 64c632c3bf21a92cedf025b40520d47973fc425bef0ce9b6c45757fe26413488
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-search_1.3.31_amd64.deb
-    digest: f04b56fad783f6d47fb185f5582d2351409dc2a156ecd1015bccb20db6b03f47
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-search_1.3.32_amd64.deb
+    digest: a0dad3d72829a19b47530e6c611a1e033d104723a105c355d1d3a2f2aaa80c51
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.5.17_amd64.deb
-    digest: 5ae14324346a37b712b0ba1e2dda259eb49035bb5176c1e4cb2a0e445df3083d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/deepin-movie-reborn/libdmr_6.5.19_amd64.deb
+    digest: 80f242e131a2f58fc38eddd7acafd10f9e6808755083e47c3a434c9a1e4af181
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.21_amd64.deb
     digest: 0b94bd183f24c9161756c6058e7d24f974f2d39680b0dd9b5adb834c2ba35ed8
@@ -715,14 +715,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4_amd64.deb
     digest: 63b2c4d61d1e41070896b399b52c4b38cd5cc529b66692394b4dbe7f5375dad4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_amd64.deb
-    digest: 1b8d5463ae362465a609408e932ad0bb6968737a59af9669c1c1d3801a31ef16
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_amd64.deb
+    digest: f24f727e6c0976f6f7a728eadc4c887c847c6fa241f40c72b0db90d53441fe75
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.14.2-6_amd64.deb
-    digest: b4851121202b85ff91dc5023277cbe9e0431744ef3c9e7a88aedb8f9e9c52d66
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.15.0-2.3deepin1_amd64.deb
+    digest: 361c9ce99546dc7c4ac638132521b5c01d8c52b7a619702fd4d357f510e34e4a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.14.2-6_amd64.deb
-    digest: c4c5fa416637a08cf925dd4ec0115631b69e4f2f5f46f2094f3239167f781085
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_amd64.deb
+    digest: bda58c37ad85fd9f7d0498483b11cdcf250eda86fff6e399d13105594737857e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_amd64.deb
     digest: 758a94a3acf10d671cc056981255d2bca91e42d74e46edb27f3c89b9c5d5d3cf
@@ -919,8 +919,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_amd64.deb
     digest: 03da9ec604f5bd9ba6526c4e6cf90c5b4266818b2c9a34110d74c42b9be87646
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin1_amd64.deb
-    digest: 6e57a1e71d4e938663bfb064d370d1e8411dc5f4a5de828c24669f0dc95f6631
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin4_amd64.deb
+    digest: a1afb2975773d7ee675f61ea12720c79002d6bcb6b586a5e6975a997b60775fb
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libidn2/libidn2-0_2.3.2-2_amd64.deb
     digest: 0ac47209fe66a5906497d6fb1c76a2addaa8daa2becaa434b17d32b98dd057cc
@@ -1288,8 +1288,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/popt/libpopt0_1.18-3_amd64.deb
     digest: 1bba21a3eeb8559a266ca1aa602df76f8d39493c7a4b4dc5e9e65176714ef7d6
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin2_amd64.deb
-    digest: 48c14ad01844820e5d2d37b4ec3353529ab7e0eddd277c0d64c863d1258d3e08
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libpostproc57_6.1.1-2deepin5_amd64.deb
+    digest: 6c5525e0cc7c8c9b719ad4ba0f4fad45e717029026fd6f8052990b8767a4695b
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libp/libproxy/libproxy1v5_0.5.9-1_amd64.deb
     digest: 4ad4360252e008b89ea7885a7c27e2df5af4a45e0aede319e08b17db3c3af932
@@ -1552,8 +1552,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_amd64.deb
     digest: cda4bbbcedb3ddd9b6722acabb811b95d1a6573a60ad7e6fedfbccac843bf8f2
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_amd64.deb
-    digest: d24f878a3059bc9cfa70dc1053cb1a2aad772c63b8bc528d4ad47b089519c017
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-4_0.11.2-1_amd64.deb
+    digest: 5b8f66c4197a56ea3b044d57a7cdd5bce63804342a4eec719d5a8e0243f1a841
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_amd64.deb
     digest: 90258a13940712eca57406b2bb0d274fbdaaa2d62a45c1e60c5b123c4080d663
@@ -1570,11 +1570,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_amd64.deb
     digest: fbdb57f1b3b245ef8d92d7a29bd0b054fec010ffd245b1d633172674acbdd7cd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin2_amd64.deb
-    digest: 6dd0610dc30fe5bb3a72788b563a8c6b77aa2ff482f3394d9f7e4bbe8f8ec74a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin5_amd64.deb
+    digest: 052fd947964de35c9251f47d1b41794a2897e20510eaeb329ad065f5b73cfac1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin2_amd64.deb
-    digest: 9889c27469bacd09cbaf06ceb3f8c7b0f3210248e79d120e68b434e2adfbcb28
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin5_amd64.deb
+    digest: f2aeda13da0792eae2ed5a4ddaccf2bc358bee717cdc78fa041a9d6432644465
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/sysprof/libsysprof-capture-4-dev_46.0-1_amd64.deb
     digest: bbaacdcbf341e500cd8fbe0dfb75fc98156b0a5abf94e43105bb5f745c3168dd
@@ -1585,11 +1585,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_amd64.deb
     digest: 75f4b1c1d7e0caf4127313225fb3be35243b09df4cf93e0225f5fb27e6c4074d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_amd64.deb
-    digest: 4fdd6319d141f7950b7a0581b38a34f9a2e63f35a8ff38b2ed13a7a77e80e90e
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5_1.12-1deepin0_amd64.deb
-    digest: 6981b6a6a11c8e04e81c0e149166261c159f4860055f0dd25e3ed3cdffd14fa7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag2_2.0.2-2_amd64.deb
+    digest: ec6092e1dbe95f4a06954406151bf1e47c844baa83492ec0324c5ff21d44a49e
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/talloc/libtalloc2_2.4.2-1deepin1_amd64.deb
     digest: bd6fa97172ce6b4ec373c9983b85d9a36cbf0421e94815387de23b00a07040a9
@@ -2011,8 +2008,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nilfs-tools/nilfs-tools_2.2.8-1_amd64.deb
     digest: 962be8d15d6e2cb21f612d75a7e8d3bda923b1eeb38b3836870c4da22de593ca
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_amd64.deb
-    digest: 752849bcf3692f005746425ed4307477b665ce980135c7815538a2053e4cbfdf
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.3.3-1_amd64.deb
+    digest: c67aae5d49b31463ae5dd06443a83de69a926bc4b8090c875c25c34f4bec5f17
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/parted/parted_3.4-deepin_amd64.deb
     digest: 7f63522d0d3914c3514d5ea75fd704475b641247ae255a5033759c0eacfa8d27
@@ -2034,9 +2031,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pinentry/pinentry-curses_1.2.0-2_amd64.deb
     digest: 592dda797941374415900d91547e276459146fd248fa2b746a8e69787af0dd8c
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkg-config_1.8.1-4_amd64.deb
-    digest: e9751c5efad4e9fb2150686bfb82ad13ff8b8f7d00592d3571f70f17a61ba884
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_amd64.deb
     digest: 6d6e880665acf6c1600e779d00259242e7f58e957dda43d760b65df472ddbfbd

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.23.1
+  version: 6.5.24.1
   kind: app
   description: |
     font manager for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -85,11 +85,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryfs/cryfs_0.11.4-1+rb1_loong64.deb
     digest: 6bface8bc94c5da84250e58d56df4bd774a6e3eb7360edd6155416cd44938ffc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2.1_loong64.deb
-    digest: d8915b3382c924164b71c2cb4daafd08b3e2727ed426326f13ed9ca371386aff
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup-bin_2.7.5-1deepin2.3_loong64.deb
+    digest: fce0cdca7ba4091d6d1452633d2a3bcbf8e6295e164aa5b8a9e05b632a2e0443
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2.1_loong64.deb
-    digest: a79946bab6773fbd759b790fb74369fb5b6eef34e388cfd15ceec8eead15825d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/cryptsetup_2.7.5-1deepin2.3_loong64.deb
+    digest: f7a6bd3e1362f4f6a871717cf9da7d040747dd78bf889fad90b038ae093e1485
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dbus/dbus-bin_1.14.10-3_loong64.deb
     digest: ce3e9d3d45cdbf7b95c18d4a5f897ee5394e658b06f2f2f489b1305d675b0781
@@ -121,14 +121,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-device-formatter/dde-device-formatter_1.5.5_loong64.deb
     digest: 427de621b5aebd34f12d0fd5baadb239fdb3bc838d5da4a2a85eaab823b19e86
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.69_loong64.deb
-    digest: 1bd992b91bf6a213699c489730e8a58f8678c6df2abd677cb7fcb4fc844faa39
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-dev_6.5.74_loong64.deb
+    digest: 7316c6c18593dd00fc89673e0d85c07a11f03f49f8d701e0febb796959f09403
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.69_loong64.deb
-    digest: f46ac8468d3f664d10d481e6e805e88b50c9fc2f997bd1c2c56a10c9a68714e2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager-services-plugins_6.5.74_loong64.deb
+    digest: ffccaf6b6b291bc564208818f3a96ee5f9d6685ff27f20ad8c543c48f147ff92
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.69_loong64.deb
-    digest: 3076e83ef67167ab7c5f7b3cecbf1ffff8a7ab0ec7f93ca7157621256c30395a
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/dde-file-manager_6.5.74_loong64.deb
+    digest: dc2be2703fe64bd05f69af67e99e8d4ba71785285cbd6313d63496b8f5dca632
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/debconf/debconf_1.5.79-deepin_all.deb
     digest: ded6aaa7927ae27337ceb23d49391b4c7ec460a00ba692020e8f4e28388f345f
@@ -139,8 +139,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/q/qt6-tools/designer-qt6_6.8.0-0deepin3_loong64.deb
     digest: eab43bf5b5365d2839d6c319aa489eb239a581d8fadc3132920645bf20948a70
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/desktop-file-utils/desktop-file-utils_0.26-deepin_loong64.deb
-    digest: 1ab06af75ac5357fe59742b9411f909c2be9b112027a9b2c46f7bad36023d4c2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/desktop-file-utils/desktop-file-utils_0.28-1_loong64.deb
+    digest: 40d65b4526a5a36be3a658bf5f533cc0788324d8d2f46dbf7b69f7e62b467004
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/g/gnupg2/dirmngr_2.4.5-2_loong64.deb
     digest: be2d0223f00e328a62efa01dc7b1b41b5a2b1ac0426db283fc04fa1f4d41f963
@@ -154,11 +154,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dpkg/dpkg_1.22.6deepin4_loong64.deb
     digest: ed2c4a87410d3beea4622bbe835dab07b458a8e286be591ca34e97f2a6f6d730
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.14.2-6_loong64.deb
-    digest: 17c510572e0a51ecc5a4eba486a1cfcb55d2ac297c84f35bc7c58cbc31e6471b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3deepin1_loong64.deb
+    digest: 06fd1e3b51d4e56571e9e974fd7936aa7010220f954b9a78b239b42bbf6e94fc
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.14.2-6_loong64.deb
-    digest: 85fed3d569a4fc895efd890e842e276016aa92848ddc3419c6fdaabc02280c7f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/fontconfig_2.15.0-2.3deepin1_loong64.deb
+    digest: 383b6417f02a2850dc8dc08613ba4f188f63943deef4f707fb03b50e34627c30
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fonts-noto/fonts-croscore_20201225-deepin_all.deb
     digest: afbaf120869a08aa7dd14da9ad014de48a751aa4330534b531410bb86c411b55
@@ -304,14 +304,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/a/avahi/libavahi-glib1_0.8-5_loong64.deb
     digest: ebc3e9878fe6e898f3dad29206f6ed138a6d4fd3bf3137313ddf1f3dd14c6f26
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin2_loong64.deb
-    digest: 7a20afa0f9aacb210e8aedb636f8ec29905d19c8862664a4bc898e89c4a4ccc0
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavcodec60_6.1.1-2deepin5_loong64.deb
+    digest: 07f5f5b252e647f447c10dbc496e502e6c6e3e791f07a7ffc6bf1e11c30b1ca5
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin2_loong64.deb
-    digest: 2423da906a4fb65e9abf19a59910c614e58899ac2e4aaa522850cad7bb9576f6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavformat60_6.1.1-2deepin5_loong64.deb
+    digest: 8b045a2001e0e3e10adfcbbc4a6eee767a1af5fec93c82543eea497141d3276d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin2_loong64.deb
-    digest: 356dfdd307a6a564c2f253378fd07f5925d481d84ea650d5aaa922009dffdb8f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libavutil58_6.1.1-2deepin5_loong64.deb
+    digest: 9dffa490932e29633146b2e971046d4dd38e83e9d72ee9e01202cf529346a232
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libb/libb2/libb2-1_0.98.1-1.1_loong64.deb
     digest: 43c9bedf808d5c2b85351f73dab25e81c5674c499c293be875ac5250c4b8cca0
@@ -478,8 +478,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libx/libxcrypt/libcrypt1_4.4.36-5_loong64.deb
     digest: a9dcd576d5cd80ada64381a1727a3116545e93cf447f59c7414d1777e2993fec
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2.1_loong64.deb
-    digest: 66c9628b7026bd09af0defc6c1ceae6fc5536260b55b7b2f652e3ef1b54e505d
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/c/cryptsetup/libcryptsetup12_2.7.5-1deepin2.3_loong64.deb
+    digest: b0e1b8d1e52719495d16cca3ddd302cce8bb39738cd9bb6158f181688ad104ba
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/b/binutils/libctf-nobfd0_2.41-6deepin7_loong64.deb
     digest: c06121aeae9359ded8ff84c74ade5b03d1325b77c4a938fbd9931c8fe2caa84b
@@ -523,8 +523,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dconf/libdconf1_0.40.0-2_loong64.deb
     digest: cc045f5e127c57d0e051177ce11347f3c46f20c345786f2082f6cf11ec00ff31
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.69_loong64.deb
-    digest: a73ca733769e8fe8a2502d316aa003e7cadee73e9a2a30fdcded12532c69d795
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdde-file-manager_6.5.74_loong64.deb
+    digest: fa855ca74d19f317189f37039c56dc2f093e2e14b4e9825c6a8a0ffcb1cea38d
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libd/libde265/libde265-0_1.0.15-1_loong64.deb
     digest: b074379f8e7ec81a299a83f504e0638be77e7d155d0141feeb31f4f5879042d1
@@ -544,29 +544,29 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/l/lvm2/libdevmapper1.02.1_1.02.201-1_loong64.deb
     digest: f52242c7bc863bdf87fda9ef7accf1e12816999fb5dbfb590325399eace9052d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.69_loong64.deb
-    digest: 18c4a3f00d1615e810949138112413ea545af9d86faf1c3feb8e3386e4ce68ef
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/d/dde-file-manager/libdfm-extension_6.5.74_loong64.deb
+    digest: 4e955964bc7ceac79a7e0b4c1232d79356ede53ecf4e7de4d686d1c78e9c853f
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn-dev_1.3.31_loong64.deb
-    digest: 63861e5ca137e9df41b623f232e2277a212f327d1e5449b221acb3a5f01a434f
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn-dev_1.3.32_loong64.deb
+    digest: 11ade400718b4c11b0b8efb05c6b4b7dfa8db634c98b1ec4385591fa55fca401
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.31_loong64.deb
-    digest: b63c0f0a42f69bffbc3bdbd8dc582197c3ed7a65a0b6ec4318d707c1000cce94
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-burn_1.3.32_loong64.deb
+    digest: 6e768ec42d1c51da8ee8686ae72f9e9e3b479f7df08d4856fb996c1224ad12bd
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io-dev_1.3.31_loong64.deb
-    digest: e864c289e3532245efd49c86a9f079ff461b10d836b4294b51e4ed0ba9d45c9b
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io-dev_1.3.32_loong64.deb
+    digest: 5526f3b7620b9083936bf2ec9e20384b375820c495a963417dff0175555426d8
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.31_loong64.deb
-    digest: 41de45b216369423e366b00e474f09744d2be1ced1962b18c6f80f47c01719f6
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-io_1.3.32_loong64.deb
+    digest: f259e42128137cd958f1f25aba20f1afaa6fbac7ed57d889e4ff56b97e723677
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.31_loong64.deb
-    digest: fc33f1b7f5a61ae0ec4974027bd04de69d9caa6d6c87a9929e69a7bc134d1e91
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount-dev_1.3.32_loong64.deb
+    digest: 27e3a66194bcd1ebf3132c8f387c274c47a374e39a0fb6577cab24281834b200
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.31_loong64.deb
-    digest: a15a3659223985691391508b4601580bc116864ec10c477dca9d6895287527ec
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-mount_1.3.32_loong64.deb
+    digest: f5c9cfa166536d0e4e56de83340ee9e157b2043a0418909714a0b1dff7efad8a
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-search_1.3.31_loong64.deb
-    digest: 7c43cfd5a1f30cbf17d6abad43de25069dee5e78cc20eab26baf0e6fa6b45350
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/u/util-dfm/libdfm6-search_1.3.32_loong64.deb
+    digest: 441f5f18053d1f213794c96dfab8a48fac1bae8820b13b8d5e756fe36dfc7d49
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/d/docparser/libdocparser_1.0.21_loong64.deb
     digest: c6166a1302829b620c52971aa3ef838b6dfc675905b5a67e28771f5d71437a2b
@@ -667,14 +667,14 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fmtlib/libfmt10_10.1.1+ds1-4deepin0+rb1_loong64.deb
     digest: afa51b193209a8d67f9f610e43bc9dffadd90f61fd77112ca1f0cfb87a7bd269
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.14.2-6_loong64.deb
-    digest: 353ec48905f9c8553b1e46a60124deb598ff3a1c07ca6a0aff62b0c5ba5bae77
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig-dev_2.15.0-2.3deepin1_loong64.deb
+    digest: ae8860a596b6ef0831f0c600efca87de921427e30b2b706c6ba682ddbaa624b1
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.14.2-6_loong64.deb
-    digest: fb7dc50d5c6f70b425b95cad47a9b57633b41fb814d06fb42c9a9022c2bf0ee2
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1-dev_2.15.0-2.3deepin1_loong64.deb
+    digest: 2dab50fc7571096b965106cc36feaeeecfef3eb1d766a3bfc7456d8d559670d4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.14.2-6_loong64.deb
-    digest: db05b74e370f34d39ff896e5070fee3351a4cb938e86bc6dc852c624cc9534cb
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3deepin1_loong64.deb
+    digest: e4faee509dbabd22ea70b8d59aedef53701693356ca681d32eeb855026312c03
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libf/libfontenc/libfontenc1_1.1.4-1_loong64.deb
     digest: 36450772f287a243ed0ff6c3b5e491021c7d63f6f68a9e71711fbb6e5884c868
@@ -865,8 +865,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libice/libice6_1.0.10-1_loong64.deb
     digest: 71f07175fac63f8a51f001299a9329a38c4320df6b46e6bdda20768aa90a3456
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin1_loong64.deb
-    digest: 2ed8252419a84421d4df376a90e03cc9eb4d1a6d4ec4120a64ab4935f80e3ba8
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/i/icu/libicu74_74.2-1deepin4_loong64.deb
+    digest: d60c34f7df7c6c7b8b950d3b2996bd1dda6ea510d77de2869bd13c614a1fe00a
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libi/libidn2/libidn2-0_2.3.2-2_loong64.deb
     digest: b235fca3fd81c2e6918d54b8d71f79757d6b818cf897fde7cb3826dc23ce85b3
@@ -1411,8 +1411,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/srt/libsrt1.4-gnutls_1.4.4-4deepin0_loong64.deb
     digest: dea4a89cee5d7d70b6143ef55501595bfa963aee8777e0f1b10f46a78dc9e578
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-gcrypt-4_0.10.6-2_loong64.deb
-    digest: 55cc8ef205639767d2c5162b6424297d7866b3d77be3ec600b70ddf3345cd6d9
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh/libssh-4_0.11.2-1_loong64.deb
+    digest: 88319c457cf55da790af61d2607fd89ebbce4e14ca4361f4d23461ad5fb41e75
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/libs/libssh2/libssh2-1_1.11.1-1deepin1_loong64.deb
     digest: bb45ae77a9bd5170e8616a550c54e2c419435abce629ade62605dcf0aa544d11
@@ -1429,11 +1429,11 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/svt-av1/libsvtav1enc1d1_1.7.0+dfsg-2_loong64.deb
     digest: d402b79e3fbfa42586f89b0b86c376772ec033ff6252032e0ea7edb831a9bf2d
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin2_loong64.deb
-    digest: 62165ae4da8e988e34843872acc420a44bcc4dd65c725bec9012e3dbc97383e7
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswresample4_6.1.1-2deepin5_loong64.deb
+    digest: e720f4941d04c0107977e1fb4f7a8a72f85f1883deda6e0e7873068a35d26692
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin2_loong64.deb
-    digest: cdc134708e57d8d48bfc3379da2ae325de64d2409ec5c2217abe303f3c3d0554
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/f/ffmpeg/libswscale7_6.1.1-2deepin5_loong64.deb
+    digest: fbc99b9f58a6f950d7e885668e20702b17ba88dd5886ffec4b9adf74ac992e82
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd-shared_255.2-4deepin11_loong64.deb
     digest: 0c01dcf425021825701db5f5dca0601bde53e63fc69b547ee6132bd8d0431e7f
@@ -1441,11 +1441,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/s/systemd/libsystemd0_255.2-4deepin11_loong64.deb
     digest: 2e66a084ee5197d6ca309c766a7fb0d9a4b397359e21a5b7a920dce4695cfcf4
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5-vanilla_1.12-1deepin0_loong64.deb
-    digest: d2688537a91f78d0b816045d583542bd5bb41bf4ef6e10d49672f4bbcf639997
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag1v5_1.12-1deepin0_loong64.deb
-    digest: 68acfd7d231bdd51d3e2f0e37c54710572b6685e153f11434ab9024f20ae3492
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/t/taglib/libtag2_2.0.2-2_loong64.deb
+    digest: 01a561f564be6c9b185d53e7a7e2241eadd85f37747a63fee4f906f91d64c9fb
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/t/talloc/libtalloc2_2.4.2-1deepin1_loong64.deb
     digest: ab1a79cf50cede6667de4740261b7699daa0cb0ea61a119f86cc892f35e51dad
@@ -1840,8 +1837,8 @@ sources:
     url: http://10.20.64.92:8080/testing25_daily/pool/main/n/nilfs-tools/nilfs-tools_2.2.8-1_loong64.deb
     digest: 07f898fd00dcdbd55dd88e48dac540ae60c92548a2ae6949e930974cc7bf2897
   - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.2.14-3_loong64.deb
-    digest: 8569bcf5afca194968c0e49c3a71fbf106bdb5f6281db535142a5b8ea1a46e18
+    url: http://10.20.64.92:8080/testing25_daily/pool/main/o/ocl-icd/ocl-icd-libopencl1_2.3.3-1_loong64.deb
+    digest: 7f3efc85c206a71b7442ee3e18dfe4f2dba6c0c62c28ab38b4960be5d28998ae
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/parted/parted_3.4-deepin_loong64.deb
     digest: 32e8c2d16d323e6f03b2b6ab0f011663593d583fe91f1d46a8f3f50640a72a8b
@@ -1863,9 +1860,6 @@ sources:
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pinentry/pinentry-curses_1.2.0-2_loong64.deb
     digest: 455cb8b3a11ea0caadec238ba0981204a4da2ccc12ca1235becbaf7ca21c935d
-  - kind: file
-    url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkg-config_1.8.1-4_loong64.deb
-    digest: fb2ca56eebecd5c9dd6f9150062f349edcd4863390463d536927b6232658f8f0
   - kind: file
     url: http://10.20.64.92:8080/testing25_daily/pool/main/p/pkgconf/pkgconf-bin_1.8.1-4_loong64.deb
     digest: 872f0376191a3cc26d0fcf9f60b5a2e81d68576cf18aa24449574147e7ce697f

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.23.1
+  version: 6.5.24.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
chore: Update package URLs and digests in linglong.yaml files

- Updated coreutils and cryfs package URLs and digests across all architectures.

log: Update package URLs and digests in linglong.yaml files

## Summary by Sourcery

Update all package source definitions in linglong.yaml across ARM64, AMD64, and LOONG64 to reflect new Deepin build versions, refresh download URLs and checksums, and bump the font manager app version.

Enhancements:
- Bump deepin-font-manager version from 6.5.23.1 to 6.5.24.1 in all linglong manifests
- Upgrade core dependencies (cryptsetup, dde-file-manager, fontconfig, ffmpeg, libssh, ocl-icd, taglib, etc.) to their latest Deepin build versions across ARM64, AMD64, and LOONG64
- Replace legacy libtag1v5 packages with the newer libtag2

Chores:
- Update source URLs and SHA256 digests in all linglong.yaml files to match new package builds
- Remove outdated pkg-config entries and rely on pkgconf-bin in manifests