### PR TITLE
feat: Update translations for Lao locale

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     font manager for deepin os.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.26) unstable; urgency=medium
+
+  * Update version to 6.5.26. 
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Thu, 07 Aug 2025 17:06:18 +0800
+
 deepin-font-manager (6.5.25) unstable; urgency=medium
 
   * chore: update the help manual

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     font manager for deepin os.

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.25.1
+  version: 6.5.26.1
   kind: app
   description: |
     font manager for deepin os.

--- a/translations/deepin-font-manager_lo.ts
+++ b/translations/deepin-font-manager_lo.ts
@@ -1,0 +1,577 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
+<context>
+    <name>Category</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dsplitlistwidget.cpp" line="362"/>
+        <source>All Fonts</source>
+        <translation>ທឹងទូទៅទាំងអស់</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dsplitlistwidget.cpp" line="363"/>
+        <source>System</source>
+        <translation>ប្រព័ន្ធសូទ្រ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dsplitlistwidget.cpp" line="364"/>
+        <source>User</source>
+        <translation>អ្នកប្រើប្រាស់</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dsplitlistwidget.cpp" line="365"/>
+        <source>Favorites</source>
+        <translation>ល្បីល្បាញ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dsplitlistwidget.cpp" line="366"/>
+        <source>Active</source>
+        <translation>ប្រកប</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dsplitlistwidget.cpp" line="367"/>
+        <source>Chinese</source>
+        <translation>ចំនួនចូរសាសន៍</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dsplitlistwidget.cpp" line="368"/>
+        <source>Monospaced</source>
+        <translation>តុប្រមាស</translation>
+    </message>
+</context>
+<context>
+    <name>DFDeleteDialog</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="139"/>
+        <source>Cancel</source>
+        <comment>button</comment>
+        <translation>បំផុត</translation>
+    </message>
+</context>
+<context>
+    <name>DFDeleteTTCDialog</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="550"/>
+        <source>%1 is a font family, if you proceed, all fonts in it will be deleted</source>
+        <translation>%1 ສ່ວນປະສິດທිພາບ, ໃນການດ຀ນຕອນ, ຈະຖິ່ມີ້ທີ່ທີ່ມີ ຄວາມຢຸດຕ່າງໆ ຈະຖິ່ມີ້ຈະຖິ່ມີ້</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="544"/>
+        <source>Delete</source>
+        <comment>button</comment>
+        <translation>ລກງລົງ</translation>
+    </message>
+</context>
+<context>
+    <name>DFDisableTTCDialog</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="563"/>
+        <source>%1 is a font family, if you proceed, all fonts in it will be enabled</source>
+        <translation>%1 ສ່ວນປະສິດທිພາບ, ໃນການດ຀ນຕອນ, ຈະຖິ່ມີ້ທີ່ທີ່ມີ ຄວ້າມັນຈະຖິ່ມີ້</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="565"/>
+        <source>%1 is a font family, if you proceed, all fonts in it will be disabled</source>
+        <translation>%1 ສ່ວນປະສິດທිພາບ, ໃນການດ຀ນຕອນ, ຈະຖິ່ມີ້ທີ່ທີ່ມີ ຄວ້າມັນຈະຖິ່ມີ້ບໍ່ຈະເຮັດວຽກ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="576"/>
+        <source>Enable</source>
+        <comment>button</comment>
+        <translation>ປະຕິບັດງານ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="578"/>
+        <source>Disable</source>
+        <comment>button</comment>
+        <translation>ກຳນຶງງານ</translation>
+    </message>
+</context>
+<context>
+    <name>DFHandleTTCDialog</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="467"/>
+        <source>Apply to all selected font families</source>
+        <translation>ນຳໃຊ້ກັບທີ່ເລັ້ນທີ່ທີ່ເລັ້ນທີກ ສ່ວນປະສິດທිພາບ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="480"/>
+        <source>Cancel</source>
+        <translation>ບໍ່ເປັນແນ່ນອນ</translation>
+    </message>
+</context>
+<context>
+    <name>DFInstallErrorDialog</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfinstallerrordialog.cpp" line="103"/>
+        <source>Broken file</source>
+        <translation>ໄອບອກເປັນໄອບົ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfinstallerrordialog.cpp" line="114"/>
+        <source>Same version installed</source>
+        <translation>ເພີ່ມບໍ່ໄດ້ເພາະວ່າໃຫ້ມີບົດບາດເປັນດຽວກັນ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfinstallerrordialog.cpp" line="125"/>
+        <source>System Font</source>
+        <translation>ສ່ວນປະສິດທිພາບ ສ່ວນປະສິດທිພາບ</translation>
+    </message>
+</context>
+<context>
+    <name>DFontMgrMainWindow</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="371"/>
+        <source>Ctrl+Shift+/</source>
+        <translation>ຄຳນຳຄຳນືບ/</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="384"/>
+        <source>PgUp</source>
+        <translation>ເດვැලුම ലීපාවලා</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="403"/>
+        <source>PgDown</source>
+        <translation>ຫີ່ນ້າລຸ່ມ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="423"/>
+        <source>Ctrl+Alt+F</source>
+        <translation>ຄຳນຳຄຳນືບ + Alt + F</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="441"/>
+        <source>Ctrl+F</source>
+        <translation>ຄຳນຳຄຳນືບ + F</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="521"/>
+        <source>Ctrl+O</source>
+        <translation>ຄຳນຳຄຳນືບ + O</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="326"/>
+        <source>Ctrl+=</source>
+        <translation>ຄຳນຳຄຳນືບ + =</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="342"/>
+        <source>Ctrl+-</source>
+        <translation>Ctrl+−</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="358"/>
+        <source>Ctrl+0</source>
+        <translation>Ctrl+0</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="1654"/>
+        <source>%1 font installed</source>
+        <translation>%1 සුපාම ෍ුරු ෍ුරු ෍ුරු</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="1656"/>
+        <source>%1 fonts installed</source>
+        <translation>%1 ුුනු ෍ුරු ෍ුරු ෍ුරු</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="474"/>
+        <source>Alt+M</source>
+        <translation>អាគියුប៊ី + M</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="562"/>
+        <source>CTRL+I</source>
+        <translation>គ្រប់គ្រង + I</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="1661"/>
+        <source>Failed to install %1 font. There is not enough disk space.</source>
+        <translation>ບានล้มเหลวក្នុងការលំអៃប្រភេទវត្ថุ %1. ແບບົດບາດບໍ່ມີບ່ອນອົດທົນພพอທຸໆ.</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="1663"/>
+        <source>Failed to install %1 fonts. There is not enough disk space.</source>
+        <translation>ບានລ้มเหลวກ្នុងການລំអៃ %1 ཀຳນຳ. ແບບົດບາດບໍ່ມີບ່ອນອົດທົນພพอທຸໆ.</translation>
+    </message>
+    <message>
+        <location filename="../libdeepin-font-manager/dcopyfilesmanager.h" line="12"/>
+        <source>Fonts</source>
+        <translation>ບ្រភេນວົງຈອນ</translation>
+    </message>
+</context>
+<context>
+    <name>DFontWidget</name>
+    <message>
+        <location filename="../libdeepin-font-manager/dfontwidget.cpp" line="127"/>
+        <source>Broken file</source>
+        <translation>ཡຸດຕິບ້າງຂ້າງກົ້ງ</translation>
+    </message>
+</context>
+<context>
+    <name>DeleteConfirmDailog</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="229"/>
+        <source>This font will not be available to applications</source>
+        <translation>ບ្រភេນ རົບ ཐົດສະບຩ ང້າຈະບໍ່ມີໃຫຍ່ དີ້ໃນບົດບາດ.</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="231"/>
+        <source>These fonts will not be available to applications</source>
+        <translation>ບົດບາດ ང້າຈະບໍ່ໄດ້ໃຊ້ໃນບົດບາດ ང້າ.</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="234"/>
+        <source>The other %1 system fonts cannot be deleted</source>
+        <translation>ລូຫ្គទុក្រដេ스크ូតទាំងអត្តីទៅក្រៅទុក្រដេ스크ូតមិនអាចលើងឹកបានទេ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="237"/>
+        <source>The font &quot;%1&quot; in use cannot be deleted</source>
+        <translation>ដេសktop font &quot;%1&quot; ដែលកំពុងត្រូវបានប្រើប្រាសេនមិនអាចលើងឹកបានទេ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="240"/>
+        <source>The other %1 system fonts and the font &quot;%2&quot; in use cannot be deleted</source>
+        <translation>រូបរាងទុក្រដេសktopទាំងអត្តីទៅក្រៅនិងទុក្រដេសktop &quot;%2&quot; ដែលកំពុងត្រូវបានប្រើប្រាសេនមិនអាចលើងឹកបានទេ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="204"/>
+        <source>Are you sure you want to delete %1 font(s)?</source>
+        <translation>តើអ្នកបានជំនាញថាគឺជាទុក្រដេសktopទៅក្រៅ %1 តែមិនបានលើងឹកទេ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfdeletedialog.cpp" line="140"/>
+        <source>Delete</source>
+        <comment>button</comment>
+        <translation>លើងឹក</translation>
+    </message>
+</context>
+<context>
+    <name>Dfuninstalldialog</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontspinnerwidget.cpp" line="74"/>
+        <source>Deleting fonts, please wait...</source>
+        <translation>កំពុងលើងឹកទុក្រដេសktop, សូមរងំង</translation>
+    </message>
+</context>
+<context>
+    <name>ExceptionWindow</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfinstallerrordialog.cpp" line="151"/>
+        <source>Font Verification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfinstallerrordialog.cpp" line="252"/>
+        <source>No fonts to be installed</source>
+        <translation>មិនមែនទុក្រដេសktopអ្វីកំពុងត្រូវបានបញ្ចុចទេ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfinstallerrordialog.cpp" line="186"/>
+        <source>Exit</source>
+        <translation>ចេញចង្អៀត</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfinstallerrordialog.cpp" line="187"/>
+        <source>Continue</source>
+        <translation>បន្ត</translation>
+    </message>
+</context>
+<context>
+    <name>Font</name>
+    <message>
+        <location filename="../libdeepin-font-manager/dfontpreviewitemdef.h" line="15"/>
+        <source>Don&apos;t let your dreams be dreams</source>
+        <translation>រក្សាទុកនូវស្រាប់ដែលអ្នកស្គាល់</translation>
+    </message>
+</context>
+<context>
+    <name>FontDetailDailog</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="131"/>
+        <source>Basic info</source>
+        <translation>ព័ត៌មានមូលដ្ឋាន</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="60"/>
+        <source>Style</source>
+        <translation>របៀប</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="62"/>
+        <source>Type</source>
+        <translation>ប្រភេទ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="66"/>
+        <source>Version</source>
+        <translation>バージョン</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="72"/>
+        <source>Description</source>
+        <translation>_Description</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="73"/>
+        <source>Unknown</source>
+        <translation>មិនស្គាល់</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="78"/>
+        <source>Full name</source>
+        <translation>ឈ្មោះពេញ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="79"/>
+        <source>Ps name</source>
+        <translation>Ps ឈ្មោះ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="80"/>
+        <source>Trademark</source>
+        <translation>សញ្ញាត្រ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="123"/>
+        <source>Copyright</source>
+        <translation>របស់លេខសម្រែងចម្ងាយ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontinfoscrollarea.cpp" line="124"/>
+        <source>License Description</source>
+        <translation>ការពិពណ៌នាការអនុញ្ញាត</translation>
+    </message>
+</context>
+<context>
+    <name>Main</name>
+    <message>
+        <location filename="../deepin-font-manager/main.cpp" line="60"/>
+        <source>Font Manager</source>
+        <translation>ບົດບຳນຮບົດພຸດ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/main.cpp" line="61"/>
+        <source>Font Manager helps users install and manage fonts.</source>
+        <translation>ບົດບຳນຮບົດພຸດຊ່ວຍຜູ້ໃຊ້ຈັດການຕິດຕັ້ງແລະຈັດການບົດພຸດ.</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontspinnerwidget.cpp" line="37"/>
+        <source>Loading fonts, please wait...</source>
+        <translation>កំពុងโหลดទុក្រដេសktop, សូមរងំង</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2093"/>
+        <source>The font exported to your desktop</source>
+        <translation>ບົດພຸດຖື່ງນຳໄປຫົວໜ້າຂອງທ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2095"/>
+        <source>%1 fonts exported to your desktop</source>
+        <translation>%1 ଢົດສຳເລັດຖື່ງນຳໄປຫົວໜ້າຂອງທ່ານ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2099"/>
+        <source>Failed to export 1 font. There is not enough disk space.</source>
+        <translation>មិនអាចបញ្ចុចទុក្រដេសktop 1 បានទេ. លទ្ធភាពទុំទូទៅគឺមិនគ្រប់គ្រាន់.</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2102"/>
+        <source>Failed to export %1 fonts. There is not enough disk space.</source>
+        <translation>មិនអាចបញ្ចុចទុក្រដេសktop %1 បានទេ. លទ្ធភាពទុំទូទៅគឺមិនគ្រប់គ្រាន់.</translation>
+    </message>
+</context>
+<context>
+    <name>Menu</name>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontmenumanager.cpp" line="63"/>
+        <source>Add font</source>
+        <translation>ເພີ່ມບົດພຸດ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontmenumanager.cpp" line="71"/>
+        <source>Enable</source>
+        <translation>ປະເມີນການ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontmenumanager.cpp" line="297"/>
+        <source>Disable</source>
+        <translation>ປະເມີນບໍ່</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontmenumanager.cpp" line="73"/>
+        <source>Delete</source>
+        <translation>ລກງ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontmenumanager.cpp" line="77"/>
+        <source>Favorite</source>
+        <translation>ນຳໃຊ້ເປັນຄໍາສຳລັບ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontmenumanager.cpp" line="278"/>
+        <source>Unfavorite</source>
+        <translation>ລກງຄໍາສຳລັບ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontmenumanager.cpp" line="80"/>
+        <source>Details</source>
+        <translation>ລາຍລະອຽດ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontmenumanager.cpp" line="83"/>
+        <source>Display in file manager</source>
+        <translation>ສະແໜ້ງໃຫ້ເຫຼີມໃນບົດບຳນຮໄອົບົກ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontmenumanager.cpp" line="75"/>
+        <source>Export</source>
+        <translation>ຖື່ງນຳ</translation>
+    </message>
+</context>
+<context>
+    <name>MessageManager</name>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontpreviewlistview.cpp" line="1875"/>
+        <source>deactivated</source>
+        <translation>ປະຖິ່ງປະຕິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontpreviewlistview.cpp" line="1877"/>
+        <source>The fonts have been deactivated</source>
+        <translation>ບົດພຸດທີ່ເປັນໄດ້ຖື່ງປະຖິ່ງປະຕິ່ງແລ້ວ.</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontpreviewlistview.cpp" line="1867"/>
+        <source>%1 is in use, so you cannot disable it</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontpreviewlistview.cpp" line="1869"/>
+        <source>You cannot disable system fonts and the fonts in use</source>
+        <translation>ທ່ານບໍ່ສາມາດປະເມີນບໍ່ເຖິງບົດພຸດລະບຸດຫຼືບົດພຸດທີ່ໃນການນຳໃຊ້ໄ ཀຳ.</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/interfaces/dfontpreviewlistview.cpp" line="1871"/>
+        <source>You cannot disable system fonts</source>
+        <translation>ທ່ານບໍ່ສາມາດປະເມີນບໍ່ເຖິງບົດພຸດລະບຸດໄດ້.</translation>
+    </message>
+</context>
+<context>
+    <name>NormalInstallWindow</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfinstallnormalwindow.cpp" line="130"/>
+        <source>Install Font</source>
+        <translation>ຕິດຕັ້ງບົດ ଢົດ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfinstallnormalwindow.cpp" line="143"/>
+        <source>Verifying...</source>
+        <translation>ກຳນຳໃຊ້ການຢັ້ງຢື່,</translation>
+    </message>
+</context>
+<context>
+    <name>QuickInstallWindow</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfquickinstallwindow.cpp" line="77"/>
+        <source>Unknown</source>
+        <translation>ລະບຸດ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfquickinstallwindow.cpp" line="206"/>
+        <source>Broken file</source>
+        <translation>ບົດແງ མາເຊື່ອມງວະການບໍ່ເປັນໄປໄດ້</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfquickinstallwindow.cpp" line="227"/>
+        <source>Installed</source>
+        <translation>ຕິດຕັ້ງແລ້ ཀຳ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfquickinstallwindow.cpp" line="232"/>
+        <source>Not Installed</source>
+        <translation>ບໍ່ຖື່ງຕິດຕັ້ງ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfquickinstallwindow.cpp" line="127"/>
+        <source>Install Font</source>
+        <translation>ເພີ່ມບົດ ଢົດ</translation>
+    </message>
+</context>
+<context>
+    <name>SearchBar</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="653"/>
+        <source>Search</source>
+        <translation>ຄຳຊອກຫາ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="838"/>
+        <source>No search results</source>
+        <translation>ບໍ່ມີຜົ outcomes ངື້າງັບ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="860"/>
+        <source>No fonts</source>
+        <translation>ບໍ່ມີໂຕະຫຼຸດ</translation>
+    </message>
+</context>
+<context>
+    <name>Shortcut</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2275"/>
+        <source>Help</source>
+        <translation>ຊ່ວຍເບິ່ງ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2280"/>
+        <source>Display shortcuts</source>
+        <translation>ສະແໜ້ນື໔</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2281"/>
+        <source>Page up</source>
+        <translation>ໜ້າຂ້າງເທີງ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2282"/>
+        <source>Page down</source>
+        <translation>ໜ້າຂ້າງລຸ່ມ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2285"/>
+        <source>Delete</source>
+        <translation>ລກງ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2286"/>
+        <source>Add font</source>
+        <translation>ເພີ່ມໂຕະຫຼຸດ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2287"/>
+        <source>Favorite</source>
+        <translation>ມືໜ້າ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2288"/>
+        <source>Unfavorite</source>
+        <translation>ໜ້າອອກ</translation>
+    </message>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="2289"/>
+        <source>Font info</source>
+        <translation>ຂໍ້ນະພາບ ཀອບຄຳ</translation>
+    </message>
+</context>
+<context>
+    <name>StateBar</name>
+    <message>
+        <location filename="../deepin-font-manager/views/dfontmgrmainwindow.cpp" line="901"/>
+        <source>Input preview text</source>
+        <translation>ເບິ່ງຫຼ້າງ</translation>
+    </message>
+</context>
+</TS>

--- a/translations/desktop/desktop_lo.ts
+++ b/translations/desktop/desktop_lo.ts
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<context>
+    <name>desktop</name>
+    <message>
+        <location filename="Desktop Entry]Name" line="0"/>
+        <source>Deepin Font Manager</source>
+        <translation>Deepin ซอฟต์แวร์จัดการตัวอักษร</translation>
+    </message>
+    <message>
+        <location filename="Desktop Entry]GenericName" line="0"/>
+        <source>Font Manager</source>
+        <translation>ซอฟต์แวร์จัดการตัวอักษร</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
log: Translation update

## Summary by Sourcery

Add Lao locale translations for the font manager and update package version to 6.5.26.1

Documentation:
- Add Lao translations for deepin-font-manager UI strings
- Add Lao desktop entry translations

Chores:
- Bump package version to 6.5.26.1 for arm64, loong64, and default builds