### PR TITLE
chore: Update linglong base and runtime

### DIFF
--- a/arm64/linglong.yaml
+++ b/arm64/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.28.1
+  version: 6.5.29.1
   kind: app
   description: |
     font manager for deepin os.
 
-base: org.deepin.base/25.2.0/arm64
-runtime: org.deepin.runtime.dtk/25.2.0/arm64
+base: org.deepin.base/25.2.1/arm64
+runtime: org.deepin.runtime.dtk/25.2.1/arm64
 
 command:
   - deepin-font-manager

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.29) unstable; urgency=medium
+
+  * chore: Update linglong base and runtime
+
+ -- wangrong <wangrong@uniontech.com>  Wed, 17 Sep 2025 11:19:46 +0800
+
 deepin-font-manager (6.5.28) unstable; urgency=medium
 
   * Update version to 6.5.28. 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.28.1
+  version: 6.5.29.1
   kind: app
   description: |
     font manager for deepin os.
 
-base: org.deepin.base/25.2.0
-runtime: org.deepin.runtime.dtk/25.2.0/x86_64
+base: org.deepin.base/25.2.1
+runtime: org.deepin.runtime.dtk/25.2.1/x86_64
 
 command:
   - deepin-font-manager

--- a/loong64/linglong.yaml
+++ b/loong64/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.28.1
+  version: 6.5.29.1
   kind: app
   description: |
     font manager for deepin os.
 
-base: org.deepin.base/25.2.0/loong64
-runtime: org.deepin.runtime.dtk/25.2.0/loong64
+base: org.deepin.base/25.2.1/loong64
+runtime: org.deepin.runtime.dtk/25.2.1/loong64
 
 command:
   - deepin-font-manager


### PR DESCRIPTION
Update linglong base and runtime

Log: Update linglong base and runtime

## Summary by Sourcery

Update Deepin Font Manager (org.deepin.fontmanager) to version 6.5.29.1 and bump its Linglong base and runtime dependencies from 25.2.0 to 25.2.1 across arm64, x86_64, and loong64

Chores:
- Bump package version in Linglong manifests to 6.5.29.1
- Update base and runtime versions to 25.2.1 for all supported architectures
- Refresh debian changelog for the new release