### PR TITLE
chore: Bump version to 6.5.36

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.36) unstable; urgency=medium
+
+  * chore: Unify linglong.yaml
+
+ -- wangrong <wangrong@uniontech.com>  Thu, 05 Mar 2026 19:28:18 +0800
+
 deepin-font-manager (6.5.35) unstable; urgency=medium
 
   * build(debian): separate Qt5/Qt6 build configurations for V25/V20 support

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.35.1
+  version: 6.5.36.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
As title.

Log: Bump version to 6.5.36

## Summary by Sourcery

Chores:
- Update application version in linglong.yaml to 6.5.36.1.