### PR TITLE
fix: reset m_fIsDeleting on cancel by listening to DFDeleteDialog::re…

### DIFF
--- a/deepin-font-manager/views/dfontmgrmainwindow.cpp
+++ b/deepin-font-manager/views/dfontmgrmainwindow.cpp
@@ -2194,6 +2194,7 @@ void DFontMgrMainWindow::delCurrentFont(bool activatedByRightmenu)
     DFDeleteDialog *confirmDelDlg = new DFDeleteDialog(this, m_menuDelCnt, m_menuSysCnt, m_menuCurCnt > 0, this);
 
     connect(confirmDelDlg, &DFDeleteDialog::accepted, this, &DFontMgrMainWindow::onconfirmDelDlgAccept);
+    connect(confirmDelDlg, &DFDeleteDialog::rejected, this, &DFontMgrMainWindow::cancelDelete);
 
     //confirmDelDlg->move((this->width() - confirmDelDlg->width() - 230 + mapToGlobal(QPoint(0, 0)).x()), (mapToGlobal(QPoint(0, 0)).y() + 180));
     confirmDelDlg->move(this->geometry().center() - confirmDelDlg->rect().center());


### PR DESCRIPTION

log: Pressing Cancel on the delete-confirmation dialog triggers reject() + close() on an already-hidden dialog, on which DDialog::closed is not reliably emitted. As a result cancelDelete() was never called and m_fIsDeleting stayed at Deleting, so the next call to delCurrentFont() was blocked at the entry gate `if (m_fIsDeleting > UnDeleting) return;`, making the confirmation dialog fail to appear on every subsequent right-click delete.

Connect DFDeleteDialog::rejected directly to cancelDelete() so the delete state flag is always reset on the cancel path.

pms: bug-347229

## Summary by Sourcery

Bug Fixes:
- Hook up the delete-confirmation dialog's rejection signal to the cancellation handler so subsequent delete attempts are no longer blocked after pressing Cancel.