### PR TITLE
fix: update version to 6.5.38

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-font-manager (6.5.39) unstable; urgency=medium
+
+  * update version to 6.5.39. 
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Thu, 28 May 2026 19:59:59 +0800
+
 deepin-font-manager (6.5.38) unstable; urgency=medium
 
   * fix: reset m_fIsDeleting on cancel by listening to DFDeleteDialog::rejected

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.38.1
+  version: 6.5.39.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
log: update version.

## Summary by Sourcery

Bump the application package version metadata to 6.5.39.1.

Enhancements:
- Update packaging configuration to reflect the new 6.5.39.1 release version.

Build:
- Adjust package version in linglong.yaml for the new release.