### PR TITLE
test: migrate unit tests from Qt5 to Qt6 compatibility

### DIFF
--- a/deepin-font-manager/interfaces/dfontpreviewer.cpp
+++ b/deepin-font-manager/interfaces/dfontpreviewer.cpp
@@ -78,7 +78,7 @@ void DFontPreviewer::onPreviewFontChanged()
     qDebug() << "Preview font changed, path:" << m_fontPath;
     m_previewTexts.clear();
     InitData();
-    foreach (auto it, m_previewTexts) {
+    for (const auto &it : m_previewTexts) {
         QString text = Utils::convertToPreviewString(m_fontPath, it);
         m_previewTexts.replaceInStrings(it, text);
     }
@@ -150,7 +150,7 @@ void DFontPreviewer::paintEvent(QPaintEvent *event)
     painter.setPen(oldPen);
 
     QRect startRect(0, topSpace, event->rect().width(), textHeight);
-    foreach (auto it, m_previewTexts) {
+    for (const auto &it : m_previewTexts) {
         painter.drawText(startRect, Qt::AlignCenter, it);
 
         startRect.setY(startRect.y() + textHeight);

--- a/deepin-font-manager/interfaces/dfontpreviewlistdatathread.cpp
+++ b/deepin-font-manager/interfaces/dfontpreviewlistdatathread.cpp
@@ -665,7 +665,7 @@ void DFontPreviewListDataThread:: refreshFontListData(bool isStartup, const QStr
         DFMDBManager::instance()->commitDeleteFontInfo();
         m_view->enableFonts();
 
-        foreach (auto it, m_startModelList) {
+        for (const auto &it : m_startModelList) {
             addPathWatcher(it.fontInfo.filePath);
         }
         m_delFontInfoList.clear();
@@ -765,7 +765,7 @@ void DFontPreviewListDataThread::refreshStartupFontListData()
     DFMDBManager::instance()->commitDeleteFontInfo();
     m_view->enableFonts();
 
-    foreach (auto it, m_startModelList) {
+    for (const auto &it : m_startModelList) {
         addPathWatcher(it.fontInfo.filePath);
     }
 

--- a/deepin-font-manager/interfaces/dfontpreviewlistview.cpp
+++ b/deepin-font-manager/interfaces/dfontpreviewlistview.cpp
@@ -2355,7 +2355,7 @@ void DFontPreviewListView::updateChangedFile(const QStringList &pathlist)
     qDebug() << __FUNCTION__ << pathlist << " begin ";
     QMutexLocker locker(&m_mutex);
 
-    foreach (auto it, pathlist) {
+    for (const auto &it : pathlist) {
         changeFontFile(it);
     }
 

--- a/deepin-font-manager/interfaces/getuseraddfontthread.cpp
+++ b/deepin-font-manager/interfaces/getuseraddfontthread.cpp
@@ -31,7 +31,7 @@ void GetUserAddFontThread::run()
     QStringList reduceSameFontList;
     DFontInfo fontInfo;
     //通过fc-list获取安装字体并与数据库对比，如果存在选项不在数据库这该字体不是通过字体管理器安装，把它加入列表
-    foreach (auto it, fclistPathList) {
+    for (const auto &it : fclistPathList) {
         if (!dbPathlist.contains(it)) {
             qDebug() << "Found user-added font:" << it;
             fontInfo = fontInfoManager->getFontInfo(it, true);

--- a/deepin-font-manager/interfaces/loadfontdatathread.cpp
+++ b/deepin-font-manager/interfaces/loadfontdatathread.cpp
@@ -37,7 +37,7 @@ void LoadFontDataThread::run()
     thread->getView()->enableFonts();
 
     qDebug() << "Setting up file watchers for" << fontinfoList.size() << "fonts";
-    foreach (auto it, fontinfoList) {
+    for (const auto &it : fontinfoList) {
         thread->addPathWatcher(it.fontInfo.filePath);
     }
 

--- a/deepin-font-manager/views/dfontmgrmainwindow.cpp
+++ b/deepin-font-manager/views/dfontmgrmainwindow.cpp
@@ -1226,7 +1226,7 @@ void DFontMgrMainWindow::installFontFromSys(const QStringList &files)
         this->m_isFromSys = true;
 
         QStringList reduceSameFiles;
-        foreach (auto it, files) {
+        for (const auto &it : files) {
             if (!reduceSameFiles.contains(it)) {
                 reduceSameFiles.append(it);
             }
@@ -2314,7 +2314,7 @@ void DFontMgrMainWindow::dropEvent(QDropEvent *event)
 
         if (dragFiles.size() > 1) {
             // qDebug() << "dragFiles.size() > 1";
-            foreach (auto it, event->mimeData()->urls()) {
+            for (const auto &it : event->mimeData()->urls()) {
                 if (Utils::isFontMimeType(it.path())) {
                     installFileList.append(it.path());
                 }

--- a/libdeepin-font-manager/dfontinfomanager.cpp
+++ b/libdeepin-font-manager/dfontinfomanager.cpp
@@ -749,7 +749,11 @@ QStringList DFontInfoManager::getCurrentFontFamily()
     QStringList retStrList;
     QProcess process;
 
+#if QT_VERSION_MAJOR > 5
+    process.startCommand("fc-match");
+#else
     process.start("fc-match");
+#endif
     process.waitForFinished(-1);
 
     QString output = process.readAllStandardOutput();
@@ -832,7 +836,11 @@ QString DFontInfoManager::getFontPath()
     QStringList retStrList;
     QProcess process;
 
+#if QT_VERSION_MAJOR > 5
+    process.startCommand("fc-match -v |grep file");
+#else
     process.start("fc-match -v |grep file");
+#endif
     process.waitForFinished(-1);
 
     QString output = process.readAllStandardOutput();

--- a/libdeepin-font-manager/fontmanagercore.cpp
+++ b/libdeepin-font-manager/fontmanagercore.cpp
@@ -295,7 +295,11 @@ void FontManagerCore::doUninstall(const QStringList &fileList)
     qDebug() << "Uninstall completed, files removed:" << m_uninstFile.size();
 
 //发现开机后先删除字体再安装字体时，偶现安装进程无法启动，修改这里后现象消失
+#if QT_VERSION_MAJOR > 5
+    bool ret = QProcess::startDetached("fc-cache", QStringList());
+#else
     bool ret = QProcess::startDetached("fc-cache");
+#endif
     Q_EMIT uninstallFcCacheFinish();
     qDebug() << "Font cache refresh result:" << ret;
 }
@@ -393,7 +397,11 @@ void FontManagerCore::doCache()
 {
     qDebug() << "Refreshing font cache";
     QProcess process;
+#if QT_VERSION_MAJOR > 5
+    process.startCommand("fc-cache");
+#else
     process.start("fc-cache");
+#endif
     process.waitForFinished(-1);
     Q_EMIT  cacheFinish();
     qDebug() << "Font cache refresh completed";

--- a/tests/src/deepin-font-manager-test/interfaces/ut_dfontpreviewlistview.cpp
+++ b/tests/src/deepin-font-manager-test/interfaces/ut_dfontpreviewlistview.cpp
@@ -986,7 +986,11 @@ TEST_F(TestDFontPreviewListView, checkIfHasSelection)
 TEST_F(TestDFontPreviewListView, checkMousePressEventLeft)
 {
     listview->m_fontPreviewProxyModel->insertRows(0, 5);
+#if QT_VERSION_MAJOR > 5
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#else
     QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#endif
     listview->mousePressEvent(e);
     delete  e;
 }
@@ -998,7 +1002,11 @@ TEST_F(TestDFontPreviewListView, checkMousePressEventRight)
     s.set(ADDR(DFontPreviewListView, onMouseRightBtnPressed), stub_Return);
 
     listview->m_fontPreviewProxyModel->insertRows(0, 5);
+#if QT_VERSION_MAJOR > 5
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(), Qt::RightButton, Qt::NoButton, Qt::NoModifier);
+#else
     QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::RightButton, Qt::NoButton, Qt::NoModifier);
+#endif
     listview->mousePressEvent(e);
     delete  e;
 }
@@ -1008,7 +1016,7 @@ TEST_F(TestDFontPreviewListView, checkMousePressEventMid)
     listview->m_fontPreviewProxyModel->insertRows(0, 5);
     listview->selectAll();
 #if QT_VERSION_MAJOR > 5
-    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MiddleButton, Qt::NoButton, Qt::NoModifier);
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(), Qt::MiddleButton, Qt::NoButton, Qt::NoModifier);
 #else
     QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MidButton, Qt::NoButton, Qt::NoModifier);
 #endif
@@ -1018,7 +1026,7 @@ TEST_F(TestDFontPreviewListView, checkMousePressEventMid)
 
     listview->clearSelection();
 #if QT_VERSION_MAJOR > 5
-    QMouseEvent *e2 = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MiddleButton, Qt::NoButton, Qt::ShiftModifier);
+    QMouseEvent *e2 = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(), Qt::MiddleButton, Qt::NoButton, Qt::ShiftModifier);
 #else
     QMouseEvent *e2 = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MidButton, Qt::NoButton, Qt::ShiftModifier);
 #endif
@@ -1028,7 +1036,7 @@ TEST_F(TestDFontPreviewListView, checkMousePressEventMid)
 
     listview->selectAll();
 #if QT_VERSION_MAJOR > 5
-    QMouseEvent *e3 = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MiddleButton, Qt::NoButton, Qt::ShiftModifier);
+    QMouseEvent *e3 = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(), Qt::MiddleButton, Qt::NoButton, Qt::ShiftModifier);
 #else
     QMouseEvent *e3 = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MidButton, Qt::NoButton, Qt::ShiftModifier);
 #endif
@@ -1036,7 +1044,7 @@ TEST_F(TestDFontPreviewListView, checkMousePressEventMid)
     SAFE_DELETE_ELE(e3);
 
 #if QT_VERSION_MAJOR > 5
-    QMouseEvent *e4 = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MiddleButton, Qt::NoButton, Qt::ControlModifier);
+    QMouseEvent *e4 = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(), Qt::MiddleButton, Qt::NoButton, Qt::ControlModifier);
 #else
     QMouseEvent *e4 = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MidButton, Qt::NoButton, Qt::ControlModifier);
 #endif
@@ -1047,7 +1055,7 @@ TEST_F(TestDFontPreviewListView, checkMousePressEventMid)
     s.set(ADDR(QModelIndex, isValid), stub_False);
     listview->selectAll();
 #if QT_VERSION_MAJOR > 5
-    QMouseEvent *e5 = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MiddleButton, Qt::NoButton, Qt::NoModifier);
+    QMouseEvent *e5 = new QMouseEvent(QEvent::MouseButtonPress, QPointF(), QPointF(), Qt::MiddleButton, Qt::NoButton, Qt::NoModifier);
 #else
     QMouseEvent *e5 = new QMouseEvent(QEvent::MouseButtonPress, QPoint(), Qt::MidButton, Qt::NoButton, Qt::NoModifier);
 #endif
@@ -1108,16 +1116,28 @@ TEST_F(TestDFontPreviewListView, checkmouseMoveEvent)
 //    s.set(ADDR(QModelIndex, isValid), stub_isValid);
 
     listview->m_fontPreviewProxyModel->insertRows(0, 5);
+#if QT_VERSION_MAJOR > 5
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseMove, QPointF(623, 23), QPointF(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#else
     QMouseEvent *e = new QMouseEvent(QEvent::MouseMove, QPoint(623, 23), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#endif
     listview->mouseMoveEvent(e);
 //    EXPECT_TRUE(listview->m_hoverModelIndex.row() == 0);
 
     listview->m_isMousePressNow = true;
+#if QT_VERSION_MAJOR > 5
+    QMouseEvent *e2 = new QMouseEvent(QEvent::MouseMove, QPointF(623, 23), QPointF(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#else
     QMouseEvent *e2 = new QMouseEvent(QEvent::MouseMove, QPoint(623, 23), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#endif
     listview->mouseMoveEvent(e2);
 //    EXPECT_TRUE(listview->m_previousPressPos == 0);
 
+#if QT_VERSION_MAJOR > 5
+    QMouseEvent *e3 = new QMouseEvent(QEvent::MouseMove, QPointF(423, 23), QPointF(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#else
     QMouseEvent *e3 = new QMouseEvent(QEvent::MouseMove, QPoint(423, 23), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#endif
     listview->mouseMoveEvent(e3);
 
     SAFE_DELETE_ELE(e);
@@ -1203,13 +1223,17 @@ TEST_F(TestDFontPreviewListView, checkMouseReleaseEvent)
     s.set(ADDR(DFontPreviewListView, onMouseLeftBtnReleased), stub_Return);
 
 #if QT_VERSION_MAJOR > 5
-    QMouseEvent *e1 = new QMouseEvent(QEvent::MouseButtonRelease, QPoint(623, 23), Qt::MiddleButton, Qt::NoButton, Qt::NoModifier);
+    QMouseEvent *e1 = new QMouseEvent(QEvent::MouseButtonRelease, QPointF(623, 23), QPointF(), Qt::MiddleButton, Qt::NoButton, Qt::NoModifier);
 #else
     QMouseEvent *e1 = new QMouseEvent(QEvent::MouseButtonRelease, QPoint(623, 23), Qt::MidButton, Qt::NoButton, Qt::NoModifier);
 #endif
     listview->mouseReleaseEvent(e1);
 
+#if QT_VERSION_MAJOR > 5
+    QMouseEvent *e2 = new QMouseEvent(QEvent::MouseButtonRelease, QPointF(623, 23), QPointF(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#else
     QMouseEvent *e2 = new QMouseEvent(QEvent::MouseButtonRelease, QPoint(623, 23), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#endif
     listview->mouseReleaseEvent(e2);
 
     SAFE_DELETE_ELE(e1);

--- a/tests/src/deepin-font-manager-test/views/ut_dfontmgrmainwindow.cpp
+++ b/tests/src/deepin-font-manager-test/views/ut_dfontmgrmainwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -610,9 +610,9 @@ TEST_F(TestDFontMgrMainWindow, checkDropEvent)
 TEST_F(TestDFontMgrMainWindow, checkDragEnterEvent)
 {
 
-    QPoint p(300, 300);
     QMimeData data;
 
+    QPoint p(300, 300);
     QDragEnterEvent *e = new QDragEnterEvent(p, Qt::CopyAction, &data, Qt::LeftButton, Qt::NoModifier);
     fm->dropEvent(e);
     EXPECT_FALSE(e->isAccepted());

--- a/tests/src/deepin-font-manager-test/views/ut_dsplitlistwidget.cpp
+++ b/tests/src/deepin-font-manager-test/views/ut_dsplitlistwidget.cpp
@@ -201,7 +201,11 @@ TEST_F(TestDSplitListWidget, checkWheelEventDeltaN)
 
 TEST_F(TestDSplitListWidget, checkMouseMoveEvent)
 {
+#if QT_VERSION_MAJOR > 5
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseMove, QPointF(600, 500), QPointF(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#else
     QMouseEvent *e = new QMouseEvent(QEvent::MouseMove, QPoint(600, 500), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#endif
 
     dsp->mouseMoveEvent(e);
     EXPECT_TRUE(dsp->m_isMouseMoved);
@@ -292,7 +296,11 @@ TEST_F(TestDSplitListWidget, checkPaint)
 TEST_F(TestDSplitListWidget, checkMouseReleaseEvent)
 {
     dsp->m_isIstalling = true;
+#if QT_VERSION_MAJOR > 5
+    QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonRelease, QPointF(), QPointF(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#else
     QMouseEvent *e = new QMouseEvent(QEvent::MouseButtonRelease, QPoint(), Qt::LeftButton, Qt::NoButton, Qt::NoModifier);
+#endif
     dsp->mouseMoveEvent(e);
 
     Stub s;

--- a/tests/third-party/stub/stub.h
+++ b/tests/third-party/stub/stub.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -43,7 +43,7 @@
     #define REPLACE_FAR(t, fn, fn_stub)\
         ((uint32_t*)fn)[0] = 0x58000040 | 9;\
         ((uint32_t*)fn)[1] = 0xd61f0120 | (9 << 5);\
-        *(long long *)(fn + 8) = (long long )fn_stub;\
+        { long long _stub_val = (long long)fn_stub; std::memcpy(fn + 8, &_stub_val, sizeof(_stub_val)); }\
         CACHEFLUSH((char *)fn, CODESIZE);
     #define REPLACE_NEAR(t, fn, fn_stub) REPLACE_FAR(t, fn, fn_stub)
 #elif defined(__arm__) || defined(_M_ARM)
@@ -68,7 +68,7 @@
     #define REPLACE_FAR(t, fn, fn_stub)\
         *fn = 0x49;\
         *(fn + 1) = 0xbb;\
-        *(long long *)(fn + 2) = (long long)fn_stub;\
+        { long long _stub_val = (long long)fn_stub; std::memcpy(fn + 2, &_stub_val, sizeof(_stub_val)); }\
         *(fn + 10) = 0x41;\
         *(fn + 11) = 0xff;\
         *(fn + 12) = 0xe3;\
@@ -77,7 +77,7 @@
     //5 byte(jmp rel32)
     #define REPLACE_NEAR(t, fn, fn_stub)\
         *fn = 0xE9;\
-        *(int *)(fn + 1) = (int)(fn_stub - fn - CODESIZE_MIN);\
+        { int _stub_val = (int)(fn_stub - fn - CODESIZE_MIN); std::memcpy(fn + 1, &_stub_val, sizeof(_stub_val)); }\
         //CACHEFLUSH((char *)fn, CODESIZE);
 #endif
 


### PR DESCRIPTION
- Add QT_VERSION_MAJOR guards for QMouseEvent constructors (QPoint->QPointF)
- Replace foreach macro with C++11 range-based for loops
- Replace QProcess::start(cmd) with startCommand() for Qt6
- Fix ASAN misaligned write crash in stub.h using memcpy

- 为QMouseEvent构造函数添加Qt6兼容分支（QPoint→QPointF）
- 将foreach宏替换为C++11 range-for循环
- 将QProcess::start()单参数调用替换为startCommand()
- 修复stub.h中ASAN非对齐写入崩溃（memcpy替代指针解引用）

Log: 迁移单元测试支持Qt6编译运行
Influence: 单元测试可在Qt6环境下编译运行，361/368测试通过，兼容Qt5编译。