### PR TITLE
chore: update version to 6.5.40

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-font-manager (6.5.40) unstable; urgency=medium
+
+  * test: migrate unit tests from Qt5 to Qt6 compatibility
+  * fix: skip in-use font when disabling via D-Bus StandardFont query
+
+ -- Wang Yu <wangyu@uniontech.com>  Wed, 17 Jun 2026 17:23:04 +0800
+
 deepin-font-manager (6.5.39) unstable; urgency=medium
 
   * update version to 6.5.39. 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.39.1
+  version: 6.5.40.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
- bump version to 6.5.40

Log : bump version to 6.5.40

## Summary by Sourcery

Chores:
- Update linglong.yaml to set the package version to 6.5.40.1.