### PR TITLE
fix: add missing semicolon to Categories in desktop entry

### DIFF
--- a/deepin-font-manager-assets/deepin-font-manager.desktop
+++ b/deepin-font-manager-assets/deepin-font-manager.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Categories=Utility
+Categories=Utility;
 Exec=deepin-font-manager %F
 GenericName=Font Manager
 Icon=deepin-font-manager


### PR DESCRIPTION
Categories field in desktop entry requires a trailing semicolon per the FreeDesktop specification.

修复desktop文件中Categories字段末尾缺少分号的问题。

Log: 修复desktop文件Categories缺少分号
PMS: https://pms.uniontech.com/bug-view-366913.html
Influence: 修复后desktop-file-validate不再报错，应用分类显示正确。

## Summary by Sourcery

Bug Fixes:
- Add the required trailing semicolon to the Categories field in the desktop entry to fix validation errors and incorrect category display.