### PR TITLE
chore: Update version to 6.5.41

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-font-manager (6.5.41) unstable; urgency=medium
+
+  * chore: Update version to 6.5.41
+  * fix: add missing semicolon to Categories in desktop entry
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 09 Jul 2026 13:26:57 +0800
+
 deepin-font-manager (6.5.40) unstable; urgency=medium
 
   * test: migrate unit tests from Qt5 to Qt6 compatibility

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,13 +7,13 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.40.1
+  version: 6.5.41.1
   kind: app
   description: |
     font manager for deepin os.
 
 base: org.deepin.base/25.2.2
-runtime: org.deepin.runtime.dtk/25.2.2
+runtime: org.deepin.runtime.dtk/6.7.0
 
 command:
   - deepin-font-manager


### PR DESCRIPTION
- update version to 6.5.41

log: update version to 6.5.41

## Summary by Sourcery

Build:
- Update linglong.yaml to use deepin-font-manager version 6.5.41.1 and runtime org.deepin.runtime.dtk/6.7.0.