### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/deepin-font-manager-assets/deepin-font-manager.desktop
+++ b/deepin-font-manager-assets/deepin-font-manager.desktop
@@ -101,7 +101,7 @@ Name[tr]=Deepin Yazı Tipi Yöneticisi
 Name[ug]=Deepin خەت شەكلى   باشقۇرغۇچ
 Name[uk]=Керування шрифтами Deepin
 Name[vi]=Quản lý Font
-Name[zh_CN]=深度字体管理器
-Name[zh_HK]=Deepin 字體管理器
-Name[zh_TW]=Deepin 字體管理器
+Name[zh_CN]=字体管理器
+Name[zh_HK]=字體管理器
+Name[zh_TW]=字體管理器
 


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Remove brand prefixes from Chinese Name/Comment translations in the font manager desktop file to align with updated branding.