### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/deepin-font-manager-assets/deepin-font-manager.desktop
+++ b/deepin-font-manager-assets/deepin-font-manager.desktop
@@ -9,6 +9,7 @@ StartupNotify=false
 TryExec=deepin-font-manager
 Type=Application
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Enhancements:
- Add X-Deepin-Singleton=true flag to the deepin-font-manager desktop file to identify it as a singleton app.