### PR TITLE
chore: Update version to 6.5.42

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-font-manager (6.5.42) unstable; urgency=medium
+
+  * chore: Update version to 6.5.42
+  * chore: Sync by https://github.com/linuxdeepin/.github/commit/826bedc64f009f4d9ebb5fba0ffe1637f1f02667
+  * fix: add X-Deepin-Singleton flag to desktop file
+  * fix: remove deepin prefix from Chinese translations in desktop file
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 30 Jul 2026 15:12:08 +0800
+
 deepin-font-manager (6.5.41) unstable; urgency=medium
 
   * chore: Update version to 6.5.41

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.41.1
+  version: 6.5.42.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
- update version to 6.5.42

log: update version to 6.5.42

## Summary by Sourcery

Bump deepin-font-manager package metadata to version 6.5.42.1.

Build:
- Update linglong package configuration to reference version 6.5.42.1.

Chores:
- Refresh packaging/changelog metadata to reflect the 6.5.42 release.