### PR TITLE
chore: Update version to 6.5.43

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-font-manager (6.5.43) unstable; urgency=medium
+
+  * chore: Update version to 6.5.43
+  * chore: add call-update-changelog workflow
+  * chore: update Portuguese translation
+
+ -- Tian ShiLin <tianshilin@uniontech.com>  Fri, 28 Aug 2026 09:59:59 +0800
+
 deepin-font-manager (6.5.42) unstable; urgency=medium
 
   * chore: Update version to 6.5.42

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -7,7 +7,7 @@ version: "1"
 package:
   id: org.deepin.fontmanager
   name: "deepin-font-manager"
-  version: 6.5.42.1
+  version: 6.5.43.1
   kind: app
   description: |
     font manager for deepin os.


### PR DESCRIPTION
Update debian/changelog and linglong.yaml version.

更新debian/changelog和玲珑配置版本号至6.5.43。

Log: 升级版本至6.5.43，同步上游rebase变更
Influence: 版本号更新至6.5.43，玲珑版本6.5.43.1

## Summary by Sourcery

Build:
- Update the package metadata and Debian changelog for the 6.5.43 release, including Linglong version 6.5.43.1.